### PR TITLE
fix glibc version issues in the linux binary

### DIFF
--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -84,7 +84,7 @@ jobs:
         run: |
           mkdir -p release
           echo "Building binary file for target: ${{ matrix.goos }}${{ matrix.goarch }}"
-          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ./release/ndc-elasticsearch-cli-${{ matrix.target }}${{ matrix.extension }}
+          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build -o ./release/ndc-elasticsearch-cli-${{ matrix.target }}${{ matrix.extension }}
           
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use static linking to resolve `glibc` version issues
+
 ## [0.1.1]
 
 - Fixed the configuration directory environment variable in the CLI.


### PR DESCRIPTION
Use static linking to resolve `glibc` version issues in the generated binary for linux.