### PR TITLE
remove `date_range_query` as a comparison operator

### DIFF
--- a/connector/static_types.go
+++ b/connector/static_types.go
@@ -306,10 +306,10 @@ func getComparisonOperatorDefinition(dataType string) map[string]schema.Comparis
 		"terms":        schema.NewComparisonOperatorCustom(schema.NewArrayType(schema.NewNamedType(dataType))).Encode(),
 	}
 
-	if dataType == "date" {
-		requiredObjectTypes["date_range_query"] = objectTypeMap["date_range_query"]
-		comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("date_range_query")).Encode()
-	}
+	// if dataType == "date" { // TODO: add back once object types are supported as comparison operators
+		// requiredObjectTypes["date_range_query"] = objectTypeMap["date_range_query"] 
+		// comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("date_range_query")).Encode()
+	// }
 
 	if dataType == "text" {
 		comparisonOperators["match_phrase_prefix"] = schema.NewComparisonOperatorCustom(schema.NewNamedType(dataType)).Encode()


### PR DESCRIPTION
This PR removes `date_range_query` because having object types as comparison operators is not fully supported yet. Merge this PR only in the worst case scenario of that support getting delayed because of unforeseen  circumstances.