### PR TITLE
add range comparison operator only to the scalar types that support it

### DIFF
--- a/connector/static_types.go
+++ b/connector/static_types.go
@@ -1,6 +1,8 @@
 package connector
 
 import (
+	"slices"
+
 	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
@@ -296,14 +298,19 @@ var objectTypeMap = map[string]schema.ObjectType{
 	},
 }
 
+var unsupportedRangeQueryScalars = []string{"binary", "completion", "_id", "wildcard", "match_only_text", "search_as_you_type"};
+
 // getComparisonOperatorDefinition generates and returns a map of comparison operators based on the provided data type.
 func getComparisonOperatorDefinition(dataType string) map[string]schema.ComparisonOperatorDefinition {
 	var comparisonOperators = map[string]schema.ComparisonOperatorDefinition{
 		"match":        schema.NewComparisonOperatorCustom(schema.NewNamedType(dataType)).Encode(),
 		"match_phrase": schema.NewComparisonOperatorCustom(schema.NewNamedType(dataType)).Encode(),
 		"term":         schema.NewComparisonOperatorCustom(schema.NewNamedType(dataType)).Encode(),
-		// "range":        schema.NewComparisonOperatorCustom(schema.NewNamedType("range")).Encode(), // TODO: add back once object types are supported as comparison operators
 		"terms":        schema.NewComparisonOperatorCustom(schema.NewArrayType(schema.NewNamedType(dataType))).Encode(),
+	}
+
+	if (!slices.Contains(unsupportedRangeQueryScalars, dataType)) {
+		comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("range")).Encode()
 	}
 
 	if dataType == "date" {


### PR DESCRIPTION
This PR cleans up range comparison operator that was previously being added to all types, even the unsupported ones.

WARNING: This hasn't been tested with the engine yet. Please test the changes with the engine before merging

All the types that do not support range comparison operation:
```
- binary
- completion
- geo_point
- geo_shape
- percolator
- _id
- wildcard
- match_only_text
- search_as_you_type
```
All these types are not added to the `unsupportedRangeQueryScalars`, because that list contains only the scalar types that do not support range operations.

To test this PR, you can use the following elasticsearch mapping that has almost all types:
```
PUT /all_data_types_index
{
  "mappings": {
    "properties": {
      "text_field": { "type": "text" },
      "keyword_field": { "type": "keyword" },
      "long_field": { "type": "long" },
      "integer_field": { "type": "integer" },
      "short_field": { "type": "short" },
      "byte_field": { "type": "byte" },
      "double_field": { "type": "double" },
      "float_field": { "type": "float" },
      "half_float_field": { "type": "half_float" },
      "scaled_float_field": { 
        "type": "scaled_float", 
        "scaling_factor": 100 
      },
      "date_field": { "type": "date" },
      "date_nanos_field": { "type": "date_nanos" },
      "boolean_field": { "type": "boolean" },
      "binary_field": { "type": "binary" },
      "integer_range_field": { "type": "integer_range" },
      "float_range_field": { "type": "float_range" },
      "long_range_field": { "type": "long_range" },
      "double_range_field": { "type": "double_range" },
      "date_range_field": { "type": "date_range" },
      "ip_range_field": { "type": "ip_range" },
      "ip_field": { "type": "ip" },
      "geo_point_field": { "type": "geo_point" },
      "geo_shape_field": { "type": "geo_shape" },
      "completion_field": { "type": "completion" },
      "token_count_field": { 
        "type": "token_count", 
        "analyzer": "standard" 
      },
      "percolator_field": { "type": "percolator" },
      "object_field": {
        "type": "object",
        "properties": {
          "nested_text_field": { "type": "text" },
          "nested_integer_field": { "type": "integer" }
        }
      },
      "flattened_field": { "type": "flattened" },
      "nested_field": {
        "type": "nested",
        "properties": {
          "nested_keyword_field": { "type": "keyword" },
          "nested_boolean_field": { "type": "boolean" }
        }
      }
    }
  }
}
```

Dummy data for the above mapping:
```
POST /all_data_types_index/_bulk
{ "index": { "_id": "1" } }
{ "text_field": "This is a sample text 1.", "keyword_field": "sample_keyword_1", "long_field": 123456789, "integer_field": 12345, "short_field": 123, "byte_field": 12, "double_field": 12345.6789, "float_field": 1234.56, "half_float_field": 123.45, "scaled_float_field": 123.456, "date_field": "2024-08-10T10:00:00Z", "date_nanos_field": "2024-08-10T10:00:00.123456789Z", "boolean_field": true, "binary_field": "U29tZSBiaW5hcnkgZGF0YQ==", "integer_range_field": { "gte": 10, "lte": 20 }, "float_range_field": { "gte": 1.5, "lte": 5.5 }, "long_range_field": { "gte": 100000, "lte": 200000 }, "double_range_field": { "gte": 100.5, "lte": 200.5 }, "date_range_field": { "gte": "2024-01-01T00:00:00Z", "lte": "2024-12-31T23:59:59Z" }, "ip_range_field": { "gte": "192.168.1.1", "lte": "192.168.1.255" }, "ip_field": "192.168.1.100", "geo_point_field": { "lat": 40.7128, "lon": -74.0060 }, "geo_shape_field": { "type": "point", "coordinates": [-74.0060, 40.7128] }, "completion_field": "completing_1", "token_count_field": 5, "object_field": { "nested_text_field": "Nested text 1", "nested_integer_field": 42 }, "flattened_field": { "field1": "value1", "field2": "value2" }, "nested_field": { "nested_keyword_field": "nested_keyword_1", "nested_boolean_field": true } }

{ "index": { "_id": "2" } }
{ "text_field": "This is a sample text 2.", "keyword_field": "sample_keyword_2", "long_field": 987654321, "integer_field": 54321, "short_field": 321, "byte_field": 21, "double_field": 54321.9876, "float_field": 4321.65, "half_float_field": 321.54, "scaled_float_field": 321.654, "date_field": "2024-07-10T10:00:00Z", "date_nanos_field": "2024-07-10T10:00:00.123456789Z", "boolean_field": false, "binary_field": "U29tZSBvdGhlciBiaW5hcnkgZGF0YQ==", "integer_range_field": { "gte": 15, "lte": 25 }, "float_range_field": { "gte": 2.0, "lte": 6.0 }, "long_range_field": { "gte": 150000, "lte": 250000 }, "double_range_field": { "gte": 150.5, "lte": 250.5 }, "date_range_field": { "gte": "2023-01-01T00:00:00Z", "lte": "2023-12-31T23:59:59Z" }, "ip_range_field": { "gte": "192.168.2.1", "lte": "192.168.2.255" }, "ip_field": "192.168.2.100", "geo_point_field": { "lat": 34.0522, "lon": -118.2437 }, "geo_shape_field": { "type": "point", "coordinates": [-118.2437, 34.0522] }, "completion_field": "completing_2", "token_count_field": 6, "object_field": { "nested_text_field": "Nested text 2", "nested_integer_field": 43 }, "flattened_field": { "field1": "value3", "field2": "value4" }, "nested_field": { "nested_keyword_field": "nested_keyword_2", "nested_boolean_field": false } }

{ "index": { "_id": "3" } }
{ "text_field": "This is a sample text 3.", "keyword_field": "sample_keyword_3", "long_field": 1122334455, "integer_field": 1234, "short_field": 23, "byte_field": 3, "double_field": 11223.3445, "float_field": 1223.34, "half_float_field": 122.33, "scaled_float_field": 122.334, "date_field": "2024-06-10T10:00:00Z", "date_nanos_field": "2024-06-10T10:00:00.123456789Z", "boolean_field": true, "binary_field": "U29tZSBtb3JlIGJpbmFyeSBkYXRh", "integer_range_field": { "gte": 20, "lte": 30 }, "float_range_field": { "gte": 3.0, "lte": 7.0 }, "long_range_field": { "gte": 200000, "lte": 300000 }, "double_range_field": { "gte": 200.5, "lte": 300.5 }, "date_range_field": { "gte": "2022-01-01T00:00:00Z", "lte": "2022-12-31T23:59:59Z" }, "ip_range_field": { "gte": "192.168.3.1", "lte": "192.168.3.255" }, "ip_field": "192.168.3.100", "geo_point_field": { "lat": 51.5074, "lon": -0.1278 }, "geo_shape_field": { "type": "point", "coordinates": [-0.1278, 51.5074] }, "completion_field": "completing_3", "token_count_field": 7, "object_field": { "nested_text_field": "Nested text 3", "nested_integer_field": 44 }, "flattened_field": { "field1": "value5", "field2": "value6" }, "nested_field": { "nested_keyword_field": "nested_keyword_3", "nested_boolean_field": true } }

{ "index": { "_id": "4" } }
{ "text_field": "This is a sample text 4.", "keyword_field": "sample_keyword_4", "long_field": 998877665, "integer_field": 9988, "short_field": 88, "byte_field": 8, "double_field": 9988.7766, "float_field": 988.77, "half_float_field": 98.88, "scaled_float_field": 98.877, "date_field": "2024-05-10T10:00:00Z", "date_nanos_field": "2024-05-10T10:00:00.123456789Z", "boolean_field": false, "binary_field": "VGVzdGluZyBiaW5hcnkgZGF0YQ==", "integer_range_field": { "gte": 25, "lte": 35 }, "float_range_field": { "gte": 4.0, "lte": 8.0 }, "long_range_field": { "gte": 250000, "lte": 350000 }, "double_range_field": { "gte": 250.5, "lte": 350.5 }, "date_range_field": { "gte": "2021-01-01T00:00:00Z", "lte": "2021-12-31T23:59:59Z" }, "ip_range_field": { "gte": "192.168.4.1", "lte": "192.168.4.255" }, "ip_field": "192.168.4.100", "geo_point_field": { "lat": 48.8566, "lon": 2.3522 }, "geo_shape_field": { "type": "point", "coordinates": [2.3522, 48.8566] }, "completion_field": "completing_4", "token_count_field": 8, "object_field": { "nested_text_field": "Nested text 4", "nested_integer_field": 45 }, "flattened_field": { "field1": "value7", "field2": "value8" }, "nested_field": { "nested_keyword_field": "nested_keyword_4", "nested_boolean_field": false } }

{ "index": { "_id": "5" } }
{ "text_field": "This is a sample text 5.", "keyword_field": "sample_keyword_5", "long_field": 5566778899, "integer_field": 5566, "short_field": 66, "byte_field": 5, "double_field": 5566.7788, "float_field": 566.78, "half_float_field": 56.67, "scaled_float_field": 56.678, "date_field": "2024-04-10T10:00:00Z", "date_nanos_field": "2024-04-10T10:00:00.123456789Z", "boolean_field": true, "binary_field": "U2FtcGxlIGJpbmFyeSBkYXRh", "integer_range_field": { "gte": 30, "lte": 40 }, "float_range_field": { "gte": 5.0, "lte": 9.0 }, "long_range_field": { "gte": 300000, "lte": 400000 }, "double_range_field": { "gte": 300.5, "lte": 400.5 }, "date_range_field": { "gte": "2020-01-01T00:00:00Z", "lte": "2020-12-31T23:59:59Z" }, "ip_range_field": { "gte": "192.168.5.1", "lte": "192.168.5.255" }, "ip_field": "192.168.5.100", "geo_point_field": { "lat": 35.6895, "lon": 139.6917 }, "geo_shape_field": { "type": "point", "coordinates": [139.6917, 35.6895] }, "completion_field": "completing_5", "token_count_field": 9, "object_field": { "nested_text_field": "Nested text 5", "nested_integer_field": 46 }, "flattened_field": { "field1": "value9", "field2": "value10" }, "nested_field": { "nested_keyword_field": "nested_keyword_5", "nested_boolean_field": true } }

```

NDC `/query` endpoint payload for running a range operation on the connector:
```
{
  "arguments": {},
  "collection": "all_data_types_index",
  "collection_relationships": {},
  "query": {
    "fields": {
      "binary_field": {
        "column": "text_field",
        "type": "column"
      }
    },
    "predicate": {
      "column": {
        "type": "column",
        "name": "_id"
      },
      "operator": "range",
      "type": "binary_comparison_operator",
      "value": {
        "type": "scalar",
        "value": {
          "gt": "19",
          "lt": "30"
        }
      }
    }
  }
}
```