### PR TITLE
Equality and _id update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+
+### Changed
+
+- Set term as the default equality operator across scalar types
+- Eliminated _id as the default uniqueness constraint
+
 ## [1.0.1]
 
 ### Changed

--- a/connector/schema.go
+++ b/connector/schema.go
@@ -55,11 +55,7 @@ func parseConfigurationToSchema(configuration *types.Configuration, state *types
 			Name:      indexName,
 			Arguments: schema.CollectionInfoArguments{},
 			Type:      indexName,
-			UniquenessConstraints: schema.CollectionInfoUniquenessConstraints{
-				indexName + "_by_id": schema.UniquenessConstraint{
-					UniqueColumns: []string{"_id"},
-				},
-			},
+			UniquenessConstraints: schema.CollectionInfoUniquenessConstraints{},
 			ForeignKeys: schema.CollectionInfoForeignKeys{},
 		})
 	}

--- a/connector/static_types.go
+++ b/connector/static_types.go
@@ -307,7 +307,7 @@ func getComparisonOperatorDefinition(dataType string) map[string]schema.Comparis
 	}
 
 	// if dataType == "date" { // TODO: add back once object types are supported as comparison operators
-		// requiredObjectTypes["date_range_query"] = objectTypeMap["date_range_query"] 
+		// requiredObjectTypes["date_range_query"] = objectTypeMap["date_range_query"]
 		// comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("date_range_query")).Encode()
 	// }
 
@@ -322,9 +322,7 @@ func getComparisonOperatorDefinition(dataType string) map[string]schema.Comparis
 		comparisonOperators["match_bool_prefix"] = schema.NewComparisonOperatorCustom(schema.NewNamedType(dataType)).Encode()
 	}
 
-	if dataType == "_id" {
-		comparisonOperators["term"] = schema.NewComparisonOperatorEqual().Encode()
-	}
+	comparisonOperators["term"] = schema.NewComparisonOperatorEqual().Encode()
 
 	return comparisonOperators
 }


### PR DESCRIPTION
- added `term` as the default equality operator across scalar types
- removed _id as the default uniqueness constraint