### PR TITLE
support sorting by subtypes

### DIFF
--- a/connector/aggregate.go
+++ b/connector/aggregate.go
@@ -31,7 +31,7 @@ func prepareAggregateQuery(ctx context.Context, aggregates schema.QueryAggregate
 		if ok {
 			aggregationColumn, path = joinFieldPath(state, fieldPath, aggregationColumn, collection)
 		}
-		validField := internal.ValidateFieldOperation(state, "aggregate", collection, aggregationColumn)
+		validField := internal.ValidateAggregateOperation(state.SupportedAggregateFields, collection, aggregationColumn)
 
 		if validField == "" {
 			return nil, schema.UnprocessableContentError("aggregation not supported on this field", map[string]any{
@@ -106,7 +106,7 @@ func prepareAggregateColumnCount(ctx context.Context, field string, path string,
 // If the field is nested, it generates a nested query to perform the specified function on the field in the nested document.
 func prepareAggregateSingleColumn(ctx context.Context, function, field string, path string, aggName string) (map[string]interface{}, error) {
 	// Validate the function
-	if !internal.Contains(validFunctions, function) {
+	if !internal.Contains(internal.ValidFunctions, function) {
 		return nil, schema.UnprocessableContentError("invalid aggregate function", map[string]any{
 			"value": function,
 		})

--- a/connector/query.go
+++ b/connector/query.go
@@ -43,7 +43,7 @@ func executeQuery(ctx context.Context, configuration *types.Configuration, state
 	prepareContext, prepareSpan := state.Tracer.Start(ctx, "prepare_elasticsearch_query")
 	defer prepareSpan.End()
 
-	dslQuery, err := prepareElasticsearchQuery(prepareContext, request, state, index)
+	dslQuery, err := prepareElasticsearchQuery(prepareContext, request, state, index, configuration)
 	if err != nil {
 		prepareSpan.SetStatus(codes.Error, err.Error())
 		return nil, err
@@ -114,7 +114,7 @@ func executeQuery(ctx context.Context, configuration *types.Configuration, state
 }
 
 // prepareElasticsearchQuery prepares an Elasticsearch query based on the provided query request.
-func prepareElasticsearchQuery(ctx context.Context, request *schema.QueryRequest, state *types.State, index string) (map[string]interface{}, error) {
+func prepareElasticsearchQuery(ctx context.Context, request *schema.QueryRequest, state *types.State, index string, configuration *types.Configuration) (map[string]interface{}, error) {
 	// Set the user configured default result size in ctx
 	ctx = context.WithValue(ctx, elasticsearch.DEFAULT_RESULT_SIZE_KEY, elasticsearch.GetDefaultResultSize())
 
@@ -155,7 +155,7 @@ func prepareElasticsearchQuery(ctx context.Context, request *schema.QueryRequest
 	span.AddEvent("prepare_sort_query")
 	// Order by
 	if request.Query.OrderBy != nil && len(request.Query.OrderBy.Elements) != 0 {
-		sort, err := prepareSortQuery(request.Query.OrderBy, state, index)
+		sort, err := prepareSortQuery(request.Query.OrderBy, state, index, configuration)
 		if err != nil {
 			return nil, err
 		}

--- a/connector/query_test.go
+++ b/connector/query_test.go
@@ -14,36 +14,65 @@ import (
 
 func TestPrepareElasticsearchQuery(t *testing.T) {
 	tests := []struct {
-		name          string
-		ndcRequest    string
-		expectedQuery string
+		name             string
+		ndcRequest       string
+		expectedQuery    string
+		configurationStr string
 	}{
 		{
-			name:          "Simple_Query_001",
-			ndcRequest:    ndcRequest_001,
-			expectedQuery: expectedQuery_001,
+			name:             "Simple_Query_001",
+			ndcRequest:       ndcRequest_001,
+			expectedQuery:    expectedQuery_001,
+			configurationStr: configuration_payments_001,
 		},
 		{
-			name:          "Simple_Query_With_Limit_002",
-			ndcRequest:    ndcRequest_002,
-			expectedQuery: expectedQuery_002,
+			name:             "Simple_Query_With_Limit_002",
+			ndcRequest:       ndcRequest_002,
+			expectedQuery:    expectedQuery_002,
+			configurationStr: configuration_payments_001,
 		},
 		{
-			name:          "Nested_Query_003",
-			ndcRequest:    ndcRequest_003,
-			expectedQuery: expectedQuery_003,
+			name:             "Nested_Query_003",
+			ndcRequest:       ndcRequest_003,
+			expectedQuery:    expectedQuery_003,
+			configurationStr: configuration_payments_001,
 		},
 		{
-			name:          "Nested_Query_With_Limit_004",
-			ndcRequest:    ndcRequest_004,
-			expectedQuery: expectedQuery_004,
+			name:             "Nested_Query_With_Limit_004",
+			ndcRequest:       ndcRequest_004,
+			expectedQuery:    expectedQuery_004,
+			configurationStr: configuration_payments_001,
+		},
+		{
+			name:             "Sort_by_Type",
+			ndcRequest:       ndcRequest_sort_001,
+			expectedQuery:    expectedQuery_sort_001,
+			configurationStr: configuration_payments_001,
+		},
+		{
+			name:             "Sort_by_Subtype",
+			ndcRequest:       ndcRequest_sort_002,
+			expectedQuery:    expectedQuery_sort_002,
+			configurationStr: configuration_payments_001,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			state := &types.State{}
+			state := &types.State{
+				Client:                   nil,
+				SupportedSortFields:      make(map[string]interface{}),
+				SupportedAggregateFields: make(map[string]interface{}),
+				SupportedFilterFields:    make(map[string]interface{}),
+				ElasticsearchInfo:        make(map[string]interface{}),
+				NestedFields:             make(map[string]interface{}),
+				Schema:                   nil, // Assuming Tracer is an interface, set to nil or an empty implementation
+			}
+
+			configuration := getConfiguration(tt.configurationStr)
+
+			ParseConfigurationToSchema(configuration, state)
 
 			ctx = context.WithValue(ctx, "postProcessor", &types.PostProcessor{})
 
@@ -51,7 +80,7 @@ func TestPrepareElasticsearchQuery(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.ndcRequest), &request)
 			assert.NoError(t, err)
 
-			query, err := prepareElasticsearchQuery(ctx, &request, state, request.Collection)
+			query, err := prepareElasticsearchQuery(ctx, &request, state, request.Collection, configuration)
 			assert.NoError(t, err)
 
 			// this correction is added because sometimes the order of _source array would change which resulted in the tests being flaky
@@ -64,6 +93,15 @@ func TestPrepareElasticsearchQuery(t *testing.T) {
 			assert.JSONEq(t, tt.expectedQuery, string(queryJson))
 		})
 	}
+}
+
+func getConfiguration(configurationStr string) *types.Configuration {
+	var configuration types.Configuration
+	err := json.Unmarshal([]byte(configurationStr), &configuration)
+	if err != nil {
+		panic(err)
+	}
+	return &configuration
 }
 
 // A helper function to sort the _source array in the query
@@ -278,4 +316,231 @@ const expectedQuery_004 = `{
 	"transaction_id"
   ],
   "size": 20
+}`
+
+const ndcRequest_sort_001 = `{
+  "arguments": {},
+  "collection": "customers",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "name": {
+        "column": "name",
+        "type": "column"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "email",
+            "path": [],
+            "type": "column"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+const expectedQuery_sort_001 = `{
+  "_source": [
+    "name"
+  ],
+  "size": 10000,
+  "sort": [
+    {
+      "email": {
+        "order": "asc"
+      }
+    }
+  ]
+}`
+
+const ndcRequest_sort_002 = `{
+  "arguments": {},
+  "collection": "customers",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "name": {
+        "column": "name",
+        "type": "column"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "name",
+            "path": [],
+            "type": "column"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+const expectedQuery_sort_002 = `{
+  "_source": [
+    "name"
+  ],
+  "size": 10000,
+  "sort": [
+    {
+      "name.keyword": {
+        "order": "asc"
+      }
+    }
+  ]
+}`
+
+const configuration_payments_001 = `{
+  "indices": {
+    "customers": {
+      "mappings": {
+        "properties": {
+          "customer_id": {
+            "type": "keyword"
+          },
+          "email": {
+            "type": "keyword"
+          },
+          "location": {
+            "type": "geo_point"
+          },
+          "name": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          }
+        }
+      }
+    },
+    "logs": {
+      "mappings": {
+        "properties": {
+          "application": {
+            "type": "keyword"
+          },
+          "log_level": {
+            "type": "keyword"
+          },
+          "message": {
+            "type": "text"
+          },
+          "timestamp": {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "metrics": {
+      "mappings": {
+        "properties": {
+          "metric_type": {
+            "type": "keyword"
+          },
+          "metric_unit": {
+            "type": "keyword"
+          },
+          "metric_value": {
+            "type": "float"
+          },
+          "timestamp": {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "payments": {
+      "mappings": {
+        "properties": {
+          "payment_method": {
+            "type": "keyword"
+          },
+          "payment_status": {
+            "type": "keyword"
+          },
+          "transaction_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    },
+    "transactions": {
+      "mappings": {
+        "properties": {
+          "customer_id": {
+            "type": "keyword"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "transaction_details": {
+            "properties": {
+              "currency": {
+                "type": "keyword"
+              },
+              "item_id": {
+                "type": "keyword"
+              },
+              "item_name": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "price": {
+                "type": "float"
+              },
+              "quantity": {
+                "type": "integer"
+              }
+            }
+          },
+          "transaction_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    },
+    "user_behavior": {
+      "mappings": {
+        "properties": {
+          "actions": {
+            "properties": {
+              "action_time": {
+                "type": "date"
+              },
+              "action_type": {
+                "type": "keyword"
+              },
+              "metadata": {
+                "type": "text"
+              }
+            },
+            "type": "nested"
+          },
+          "customer_id": {
+            "type": "keyword"
+          },
+          "session_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  },
+  "queries": {}
 }`

--- a/connector/schema.go
+++ b/connector/schema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hasura/ndc-elasticsearch/types"
 	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/hasura/ndc-elasticsearch/internal"
 )
 
 // GetSchema returns the schema by parsing the configuration.
@@ -214,15 +215,15 @@ func prepareNdcSchema(ndcSchema *schema.SchemaResponse, index string, fields []m
 	}
 
 	// Add the required fields to the schema
-	ndcSchema.ScalarTypes["_id"] = scalarTypeMap["_id"]
+	ndcSchema.ScalarTypes["_id"] = internal.ScalarTypeMap["_id"]
 
 	// ADd the required scalar type to the schema
-	for scalarTypeName, ScalarType := range requiredScalarTypes {
+	for scalarTypeName, ScalarType := range internal.RequiredScalarTypes {
 		ndcSchema.ScalarTypes[scalarTypeName] = ScalarType
 	}
 
 	// Add the required object types to the schema.
-	for objectName, objectType := range requiredObjectTypes {
+	for objectName, objectType := range internal.RequiredObjectTypes {
 		ndcSchema.ObjectTypes[objectName] = objectType
 	}
 }
@@ -239,10 +240,10 @@ func getNdcObjectFields(fields []map[string]interface{}, ndcSchema *schema.Schem
 		fieldName := field["name"].(string)
 
 		// Add scalar or object type to the schema
-		if scalarType, ok := scalarTypeMap[fieldType]; ok {
+		if scalarType, ok := internal.ScalarTypeMap[fieldType]; ok {
 			// Add the scalar type to the NDC schema
 			ndcSchema.ScalarTypes[fieldType] = scalarType
-		} else if objectType, ok := objectTypeMap[fieldType]; ok {
+		} else if objectType, ok := internal.ObjectTypeMap[fieldType]; ok {
 			// Add the object type to the NDC schema
 			ndcSchema.ObjectTypes[fieldType] = objectType
 		}

--- a/connector/sort.go
+++ b/connector/sort.go
@@ -1,16 +1,18 @@
 package connector
 
 import (
+	"fmt"
+
 	"github.com/hasura/ndc-elasticsearch/internal"
 	"github.com/hasura/ndc-elasticsearch/types"
 	"github.com/hasura/ndc-sdk-go/schema"
 )
 
 // prepareSortQuery prepares the sort query.
-func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection string) ([]map[string]interface{}, error) {
+func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection string, configuration *types.Configuration) ([]map[string]interface{}, error) {
 	sort := make([]map[string]interface{}, len(orderBy.Elements))
 	for i, element := range orderBy.Elements {
-		sortElmnt, err := prepareSortElement(&element, state, collection)
+		sortElmnt, err := prepareSortElement(&element, state, collection, configuration)
 		if err != nil {
 			return nil, err
 		}
@@ -23,19 +25,36 @@ func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection st
 //
 // It takes in the OrderByElement, state, and collection as parameters.
 // It returns the prepared sort element and an error if any.
-func prepareSortElement(element *schema.OrderByElement, state *types.State, collection string) (map[string]interface{}, error) {
+func prepareSortElement(element *schema.OrderByElement, state *types.State, collection string, configuration *types.Configuration) (map[string]interface{}, error) {
 	sort := make(map[string]interface{})
 	switch target := element.Target.Interface().(type) {
 	case *schema.OrderByColumn:
 		// Join the field path to get the field path and nested path.
 		fieldPath, nestedPath := joinFieldPath(state, target.FieldPath, target.Name, collection)
 
-		validField := internal.ValidateFieldOperation(state, "sort", collection, fieldPath)
+		validField := internal.ValidateSortOperation(state.SupportedSortFields, collection, fieldPath)
 		if validField == "" {
 			return nil, schema.UnprocessableContentError("sorting not supported on this field", map[string]any{
 				"value": fieldPath,
 			})
 		}
+
+		fieldType, fieldSubTypes, fieldDataEnabled, err := configuration.GetFieldProperties(collection, fieldPath)
+		if err != nil {
+			return nil, schema.InternalServerError("failed to get field types", map[string]any{"error": err.Error()})
+		}
+
+		if internal.IsSortSupported(fieldType, fieldDataEnabled) {
+			fieldPath = validField
+		} else {
+			for _, subType := range fieldSubTypes {
+				if internal.IsSortSupported(subType, fieldDataEnabled) {
+					validField = fmt.Sprintf("%s.%s", validField, subType)
+					break
+				}
+			}
+		}
+
 		fieldPath = validField
 		sort[fieldPath] = map[string]interface{}{
 			"order": string(element.OrderDirection),

--- a/connector/sort.go
+++ b/connector/sort.go
@@ -44,10 +44,11 @@ func prepareSortElement(element *schema.OrderByElement, state *types.State, coll
 			return nil, schema.InternalServerError("failed to get field types", map[string]any{"error": err.Error()})
 		}
 
-		if internal.IsSortSupported(fieldType, fieldDataEnabled) {
-			fieldPath = validField
-		} else {
-			for _, subType := range fieldSubTypes {
+		if !internal.IsSortSupported(fieldType, fieldDataEnabled) {
+			// we iterate over the fieldSubTypes in reverse because the subtypes are sorted by priority. 
+			// We want to use the highest priority subType that is supported for sorting.
+			for i := len(fieldSubTypes) - 1; i >= 0; i-- {
+				subType := fieldSubTypes[i]
 				if internal.IsSortSupported(subType, fieldDataEnabled) {
 					validField = fmt.Sprintf("%s.%s", validField, subType)
 					break

--- a/internal/fields.go
+++ b/internal/fields.go
@@ -1,0 +1,68 @@
+package internal
+
+// Given a fieldMap, this function extracts the type and all subtypes (if present)
+func ExtractTypes(fieldMap map[string]interface{}) (fieldAndSubfields []string) {
+	if subFields, ok := HasSubfields(fieldMap); ok {
+		for _, subFieldData := range subFields {
+			fieldAndSubfields = append(fieldAndSubfields, ExtractTypes(subFieldData.(map[string]interface{}))...)
+		}
+	}
+
+	SortTypesByPriority(fieldAndSubfields)
+
+	fieldType, _ := FieldTypeIsScalar(fieldMap)
+	fieldAndSubfields = append([]string{fieldType}, fieldAndSubfields...)
+	return fieldAndSubfields
+}
+
+func HasSubfields(fieldMap map[string]interface{}) (subFields map[string]interface{}, ok bool) {
+	subFields, ok = fieldMap["fields"].(map[string]interface{})
+	return subFields, ok
+}
+
+/**
+ * This function checks if a field is a scalar field
+ * Scalar field here refers to a field that does not have any nested fields/properties
+ */
+ func FieldTypeIsScalar(fieldMap map[string]interface{}) (fieldType string, isFieldScalar bool) {
+	fieldType, ok := fieldMap["type"].(string)
+	return fieldType, ok && fieldType != "nested" && fieldType != "object" && fieldType != "flattened"
+}
+
+// IsSortSupported checks if a field type is supported for sorting
+// based on fielddata and unsupported sort data types.
+func IsSortSupported(fieldType string, fieldDataEnalbed bool) bool {
+	if fieldDataEnalbed {
+		return true
+	}
+	for _, unSupportedType := range UnSupportedSortDataTypes {
+		if fieldType == unSupportedType {
+			return false
+		}
+	}
+	return true
+}
+
+// IsAggregateSupported checks if a field type is supported for aggregation
+// based on fielddata and unsupported aggregate data types.
+func IsAggregateSupported(fieldType string, fieldDataEnalbed bool) bool {
+	if fieldDataEnalbed {
+		return true
+	}
+
+	for _, unSupportedType := range UnSupportedAggregateTypes {
+		if fieldType == unSupportedType {
+			return false
+		}
+	}
+
+	return true
+}
+
+func IsFieldDtaEnabled(fieldMap map[string]interface{}) bool {
+	fieldDataEnalbed := false
+	if fieldData, ok := fieldMap["fielddata"].(bool); ok {
+		fieldDataEnalbed = fieldData
+	}
+	return fieldDataEnalbed
+}

--- a/internal/static_types.go
+++ b/internal/static_types.go
@@ -1,4 +1,4 @@
-package connector
+package internal
 
 import (
 	"slices"
@@ -7,11 +7,11 @@ import (
 	"github.com/hasura/ndc-sdk-go/utils"
 )
 
-var numericFields = []string{"integer", "long", "short", "byte", "halft_float", "unsigned_long", "float", "double", "scaled_float"}
+var NumericFields = []string{"integer", "long", "short", "byte", "halft_float", "unsigned_long", "float", "double", "scaled_float"}
 
-var validFunctions = []string{"sum", "min", "max", "avg", "value_count", "cardinality", "stats", "string_stats"}
+var ValidFunctions = []string{"sum", "min", "max", "avg", "value_count", "cardinality", "stats", "string_stats"}
 
-var scalarTypeMap = map[string]schema.ScalarType{
+var ScalarTypeMap = map[string]schema.ScalarType{
 	"integer": {
 		AggregateFunctions:  getAggregationFunctions([]string{"max", "min", "sum", "avg", "value_count", "cardinality", "stats"}, "integer"),
 		ComparisonOperators: getComparisonOperatorDefinition("integer"),
@@ -139,7 +139,7 @@ var scalarTypeMap = map[string]schema.ScalarType{
 // It means can a type represent another type or not.
 //
 // For example, 'string' is a higher priority than float, because every float can be represented as a string, but not vice versa.
-var typePriorityMap = map[string]int{
+var TypePriorityMap = map[string]int{
 	"binary":  1,
 	"boolean": 2,
 
@@ -167,15 +167,15 @@ var typePriorityMap = map[string]int{
 	"_id":              20,
 }
 
-var requiredScalarTypes = map[string]schema.ScalarType{
-	"double":  scalarTypeMap["double"],
-	"integer": scalarTypeMap["integer"],
-	"float":   scalarTypeMap["float"],
-	"keyword": scalarTypeMap["keyword"],
-	"long":    scalarTypeMap["long"],
+var RequiredScalarTypes = map[string]schema.ScalarType{
+	"double":  ScalarTypeMap["double"],
+	"integer": ScalarTypeMap["integer"],
+	"float":   ScalarTypeMap["float"],
+	"keyword": ScalarTypeMap["keyword"],
+	"long":    ScalarTypeMap["long"],
 }
 
-var requiredObjectTypes = map[string]schema.ObjectType{
+var RequiredObjectTypes = map[string]schema.ObjectType{
 	"stats": {
 		Fields: schema.ObjectTypeFields{
 			"count": schema.ObjectField{
@@ -240,7 +240,7 @@ var requiredObjectTypes = map[string]schema.ObjectType{
 	},
 }
 
-var objectTypeMap = map[string]schema.ObjectType{
+var ObjectTypeMap = map[string]schema.ObjectType{
 	"sparse_vector": {
 		Fields: schema.ObjectTypeFields{},
 	},
@@ -332,7 +332,7 @@ var objectTypeMap = map[string]schema.ObjectType{
 	},
 }
 
-var unsupportedRangeQueryScalars = []string{"binary", "completion", "_id", "wildcard", "match_only_text", "search_as_you_type"}
+var UnsupportedRangeQueryScalars = []string{"binary", "completion", "_id", "wildcard", "match_only_text", "search_as_you_type"}
 
 // getComparisonOperatorDefinition generates and returns a map of comparison operators based on the provided data type.
 func getComparisonOperatorDefinition(dataType string) map[string]schema.ComparisonOperatorDefinition {
@@ -343,12 +343,12 @@ func getComparisonOperatorDefinition(dataType string) map[string]schema.Comparis
 		"terms":        schema.NewComparisonOperatorCustom(schema.NewArrayType(schema.NewNamedType(dataType))).Encode(),
 	}
 
-	if !slices.Contains(unsupportedRangeQueryScalars, dataType) {
+	if !slices.Contains(UnsupportedRangeQueryScalars, dataType) {
 		comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("range")).Encode()
 	}
 
 	if dataType == "date" {
-		requiredObjectTypes["date_range_query"] = objectTypeMap["date_range_query"]
+		RequiredObjectTypes["date_range_query"] = ObjectTypeMap["date_range_query"]
 		comparisonOperators["range"] = schema.NewComparisonOperatorCustom(schema.NewNamedType("date_range_query")).Encode()
 	}
 
@@ -388,12 +388,12 @@ func getAggregationFunctions(functions []string, typeName string) schema.ScalarT
 	return aggregationFunctions
 }
 
-func sortTypesByPriority(types []string) {
+func SortTypesByPriority(types []string) {
 	for i := 0; i < len(types); i++ {
 		for j := i + 1; j < len(types); j++ {
-			if typePriorityMap[types[i]] > typePriorityMap[types[j]] {
+			if TypePriorityMap[types[i]] > TypePriorityMap[types[j]] {
 				types[i], types[j] = types[j], types[i]
-			} else if typePriorityMap[types[i]] == typePriorityMap[types[j]] {
+			} else if TypePriorityMap[types[i]] == TypePriorityMap[types[j]] {
 				// priority is same, sort alphabetically
 				if types[i] > types[j] {
 					types[i], types[j] = types[j], types[i]
@@ -404,7 +404,7 @@ func sortTypesByPriority(types []string) {
 }
 
 // unSupportedAggregateTypes are lists of data types that do not support aggregation in elasticsearch.
-var unSupportedAggregateTypes = []string{
+var UnSupportedAggregateTypes = []string{
 	"text",
 	"search_as_you_type",
 	"completion",
@@ -412,8 +412,8 @@ var unSupportedAggregateTypes = []string{
 	"binary",
 }
 
-// unsupportedSortDataTypes are lists of data types that do not support sorting in elasticsearch.
-var unsupportedSortDataTypes = []string{
+// unSupportedSortDataTypes are lists of data types that do not support sorting in elasticsearch.
+var UnSupportedSortDataTypes = []string{
 	"text",
 	"search_as_you_type",
 	"binary",

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hasura/ndc-elasticsearch/types"
 )
 
 const (
@@ -108,14 +107,15 @@ func DeepEqual(v1, v2 any) bool {
 	return reflect.DeepEqual(x1, x2)
 }
 
-// validateFieldOperation checks if the given field is supported for the specified operation in the given collection.
-// It returns the valid field name if it is supported, otherwise an empty string.
-func ValidateFieldOperation(state *types.State, operation, collection, field string) string {
-	supportedFields := state.SupportedSortFields
-	if operation == "aggregate" {
-		supportedFields = state.SupportedAggregateFields
-	}
+func ValidateAggregateOperation(supportedFields map[string]interface{}, collection, field string) string {
+	return validateOperation(supportedFields, collection, field)
+}
 
+func ValidateSortOperation(supportedFields map[string]interface{}, collection, field string) string {
+	return validateOperation(supportedFields, collection, field)
+}
+
+func validateOperation(supportedFields map[string]interface{}, collection, field string) string {
 	supportedFieldsMap, ok := supportedFields[collection].(map[string]string)
 	if !ok {
 		return field

--- a/types/types.go
+++ b/types/types.go
@@ -1,9 +1,12 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/hasura/ndc-elasticsearch/elasticsearch"
 	"github.com/hasura/ndc-sdk-go/connector"
 	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/hasura/ndc-elasticsearch/internal"
 )
 
 // State is the global state which is shared for every connector request.
@@ -22,6 +25,57 @@ type State struct {
 type Configuration struct {
 	Indices map[string]interface{} `json:"indices"`
 	Queries map[string]NativeQuery `json:"queries"`
+}
+
+func (c *Configuration) GetIndex(indexName string) (map[string]interface{}, error) {
+	index, ok := c.Indices[indexName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to find index: %s", indexName)
+	}
+
+	return index, nil
+}
+
+func (c *Configuration) GetFieldMap(indexName, fieldName string) (map[string]interface{}, error) {
+	index, err := c.GetIndex(indexName)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping, ok := index["mappings"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to find mapping in index: %s", indexName)
+	}
+
+	properties, ok := mapping["properties"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to find properties in index: %s", indexName)
+	}
+
+	fieldMap, ok := properties[fieldName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to find field `%s` in index `%s` ", fieldName, indexName)
+	}
+
+	return fieldMap, nil
+
+}
+
+func (c *Configuration) GetFieldProperties(indexName, fieldName string) (fieldType string, fieldSubTypes []string, fieldDataEnabled bool, err error) {
+	fieldMap, err := c.GetFieldMap(indexName, fieldName)
+	if err != nil {
+		return "", nil, false, err
+	}
+
+	fieldsAndSubfields := internal.ExtractTypes(fieldMap)
+
+	fieldDataEnabled = internal.IsFieldDtaEnabled(fieldMap)
+
+	if (len(fieldsAndSubfields) == 1) {
+		return fieldsAndSubfields[0], make([]string, 0), fieldDataEnabled, nil
+	}
+
+	return fieldsAndSubfields[0], fieldsAndSubfields[1:], fieldDataEnabled, nil
 }
 
 // NativeQuery contains the definition of the native query.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -1,0 +1,406 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigurationGetIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration string
+		indexName     string
+		want          string
+	}{
+		{
+			name:          "transaction_payments",
+			configuration: configurationTransactions,
+			indexName:     "payments",
+			want: `{
+  "mappings": {
+    "properties": {
+      "payment_method": {
+        "type": "keyword"
+      },
+      "payment_status": {
+        "type": "keyword"
+      },
+      "transaction_id": {
+        "type": "keyword"
+      }
+    }
+  }
+}`,
+		},
+		{
+			name:          "transaction_user_behavior",
+			configuration: configurationTransactions,
+			indexName:     "user_behavior",
+			want: `{
+  "mappings": {
+    "properties": {
+      "actions": {
+        "properties": {
+          "action_time": {
+            "type": "date"
+          },
+          "action_type": {
+            "type": "keyword"
+          },
+          "metadata": {
+            "type": "text"
+          }
+        },
+        "type": "nested"
+      },
+      "customer_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword"
+      }
+    }
+  }
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := getConfiguration(tt.configuration)
+
+			got, err := config.GetIndex(tt.indexName)
+			assert.NoError(t, err)
+
+			gotJson, err := json.MarshalIndent(got, "", "  ")
+			assert.NoError(t, err)
+
+			assert.JSONEq(t, tt.want, string(gotJson))
+		})
+	}
+}
+
+func TestConfigurationGetFieldMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		configuration string
+		indexName     string
+		fieldName     string
+		want          string
+	}{
+		{
+			name:          "transaction_customers_name",
+			configuration: configurationTransactions,
+			indexName:     "customers",
+			fieldName:     "name",
+			want: `{
+  "fields": {
+    "keyword": {
+      "ignore_above": 256,
+      "type": "keyword"
+    }
+  },
+  "type": "text"
+}`,
+		},
+		{
+			name:          "transaction_payments_paymentStatus",
+			configuration: configurationTransactions,
+			indexName:     "payments",
+			fieldName:     "payment_status",
+			want: `{
+  "type": "keyword"
+}`,
+		},
+		{
+			name:          "transaction_transactions_transactionDetails",
+			configuration: configurationTransactions,
+			indexName:     "transactions",
+			fieldName:     "transaction_details",
+			want: `{
+  "properties": {
+    "currency": {
+      "type": "keyword"
+    },
+    "item_id": {
+      "type": "keyword"
+    },
+    "item_name": {
+      "fields": {
+        "keyword": {
+          "ignore_above": 256,
+          "type": "keyword"
+        }
+      },
+      "type": "text"
+    },
+    "price": {
+      "type": "float"
+    },
+    "quantity": {
+      "type": "integer"
+    }
+  }
+}`,
+		},
+		{
+			name:          "transaction_transactions_transactionDetails_itemName",
+			configuration: configurationTransactions,
+			indexName:     "transactions",
+			fieldName:     "transaction_details.item_name",
+			want: `{
+  "fields": {
+    "keyword": {
+      "ignore_above": 256,
+      "type": "keyword"
+    }
+  },
+  "type": "text"
+}`,
+		},
+		{
+			name:          "transaction_transactions_transactionDetails_currency",
+			configuration: configurationTransactions,
+			indexName:     "transactions",
+			fieldName:     "transaction_details.currency",
+			want: `{
+  "type": "keyword"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := getConfiguration(tt.configuration)
+
+			got, err := config.GetFieldMap(tt.indexName, tt.fieldName)
+			assert.NoError(t, err)
+
+			gotJson, err := json.MarshalIndent(got, "", "  ")
+			assert.NoError(t, err)
+			fmt.Println(string(gotJson))
+			assert.JSONEq(t, tt.want, string(gotJson))
+		})
+	}
+}
+
+func TestConfigurationGetFieldProperties(t *testing.T) {
+	tests := []struct {
+		name                 string
+		configuration        string
+		indexName            string
+		fieldName            string
+		wantFieldType        string
+		wantSubtypes         []string
+		wantFieldDataEnabled bool
+	}{
+		{
+			name:                 "transaction_customers_name",
+			configuration:        configurationTransactions,
+			indexName:            "customers",
+			fieldName:            "name",
+			wantFieldType:        "text",
+			wantSubtypes:         []string{"keyword"},
+			wantFieldDataEnabled: false,
+		},
+		{
+			name:                 "transaction_logs_log_level",
+			configuration:        configurationTransactions,
+			indexName:            "logs",
+			fieldName:            "log_level",
+			wantFieldType:        "keyword",
+			wantSubtypes:         []string{},
+			wantFieldDataEnabled: false,
+		},
+		{
+			name:                 "transaction_transactions_transactionDetails_itemName",
+			configuration:        configurationTransactions,
+			indexName:            "transactions",
+			fieldName:            "transaction_details.item_name",
+			wantFieldType:        "text",
+			wantSubtypes:         []string{"keyword"},
+			wantFieldDataEnabled: false,
+		},
+		{
+			name:                 "transaction_user_behavior_actions",
+			configuration:        configurationTransactions,
+			indexName:            "user_behavior",
+			fieldName:            "actions",
+			wantFieldType:        "nested",
+			wantSubtypes:         []string{},
+			wantFieldDataEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := getConfiguration(tt.configuration)
+
+			gotFieldType, gotFieldSubTypes, gotFieldDataEnabled, err := config.GetFieldProperties(tt.indexName, tt.fieldName)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.wantFieldType, gotFieldType)
+			assert.Equal(t, tt.wantSubtypes, gotFieldSubTypes)
+			assert.Equal(t, tt.wantFieldDataEnabled, gotFieldDataEnabled)
+		})
+	}
+}
+
+func getConfiguration(configurationStr string) *Configuration {
+	var configuration Configuration
+	err := json.Unmarshal([]byte(configurationStr), &configuration)
+	if err != nil {
+		panic(err)
+	}
+	return &configuration
+}
+
+const configurationTransactions = `{
+  "indices": {
+    "customers": {
+      "mappings": {
+        "properties": {
+          "customer_id": {
+            "type": "keyword"
+          },
+          "email": {
+            "type": "keyword"
+          },
+          "location": {
+            "type": "geo_point"
+          },
+          "name": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          }
+        }
+      }
+    },
+    "logs": {
+      "mappings": {
+        "properties": {
+          "application": {
+            "type": "keyword"
+          },
+          "log_level": {
+            "type": "keyword"
+          },
+          "message": {
+            "type": "text"
+          },
+          "timestamp": {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "metrics": {
+      "mappings": {
+        "properties": {
+          "metric_type": {
+            "type": "keyword"
+          },
+          "metric_unit": {
+            "type": "keyword"
+          },
+          "metric_value": {
+            "type": "float"
+          },
+          "timestamp": {
+            "type": "date"
+          }
+        }
+      }
+    },
+    "payments": {
+      "mappings": {
+        "properties": {
+          "payment_method": {
+            "type": "keyword"
+          },
+          "payment_status": {
+            "type": "keyword"
+          },
+          "transaction_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    },
+    "transactions": {
+      "mappings": {
+        "properties": {
+          "customer_id": {
+            "type": "keyword"
+          },
+          "timestamp": {
+            "type": "date"
+          },
+          "transaction_details": {
+            "properties": {
+              "currency": {
+                "type": "keyword"
+              },
+              "item_id": {
+                "type": "keyword"
+              },
+              "item_name": {
+                "fields": {
+                  "keyword": {
+                    "ignore_above": 256,
+                    "type": "keyword"
+                  }
+                },
+                "type": "text"
+              },
+              "price": {
+                "type": "float"
+              },
+              "quantity": {
+                "type": "integer"
+              }
+            }
+          },
+          "transaction_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    },
+    "user_behavior": {
+      "mappings": {
+        "properties": {
+          "actions": {
+            "properties": {
+              "action_time": {
+                "type": "date"
+              },
+              "action_type": {
+                "type": "keyword"
+              },
+              "metadata": {
+                "type": "text"
+              }
+            },
+            "type": "nested"
+          },
+          "customer_id": {
+            "type": "keyword"
+          },
+          "session_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  },
+  "queries": {}
+}`


### PR DESCRIPTION
Completes [ENT-124](https://linear.app/hasura/issue/ENT-124/fix-sorting-issue-on-text-field-with-keyword-subtype-in-elastic)

## Description
This PR modifies the sort query generation to support fields that use subtypes to enable sorting. 

## Problem
Let's assume that there were the following index `customers` in our elasticsearch db:
```
{
  "customers": {
    "mappings": {
      "properties": {
        "customer_id": {
          "type": "keyword"
        },
        "email": {
          "type": "keyword"
        },
        "location": {
          "type": "geo_point"
        },
        "name": {
          "fields": {
            "keyword": {
              "ignore_above": 256,
              "type": "keyword"
            }
          },
          "type": "text"
        }
      }
    }
  }
}
```
Now, if we wanted to sort this `customers` index by the field `name`, the connector would generate the following sort query:
```
{
  "sort": [
    {
      "name": {
        "order": "asc"
      }
    }
  ]
}
```
This would fail, because the type of `name` is `text`, which does not support sorting. However, `name` has subtype `keyword` that allows sorting, and the query must take this into account. The correct query is:
```
{
  "sort": [
    {
      "name.keyword": {
        "order": "asc"
      }
    }
  ]
}
```

## Quick Review
The main change of this PR is in the commit [d3f4194](https://github.com/hasura/ndc-elasticsearch/pull/33/commits/d3f4194debc003ed311a38ae9daae9f145239ac7) and is refactored in [3a247ff](https://github.com/hasura/ndc-elasticsearch/pull/33/commits/3a247ff5272cd1da90a39073091319c57f43d74d), rest are all accommodating changes such as refactors, and tests.