### PR TITLE
fix `top_hits` query size

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Below, you'll find a matrix of all supported features for the Elasticsearch conn
 | Nested Sorting                  | ❌        |       |
 | Nested Relationships            | ❌        |       |
 
+> [!Note]
+> Remote Relationships are currently implemented via `top_hits` operator. That operator has a default maximum result size limit of 100 rows. This is what the connector operates on. If you give the connector a higher limit, it will change that to 100 for compliance with the database. Also, since the returned result will contain only 100 rows per bucket, it may not represent the whole result.
+
 ## Before you get Started
 
 1. Create a [Hasura Cloud account](https://console.hasura.io)

--- a/connector/variables.go
+++ b/connector/variables.go
@@ -14,6 +14,12 @@ func executeQueryWithVariables(variableSets []schema.QueryRequestVariablesElem, 
 	// do not to return any documents in the search results while performing aggregations
 	variableQuery["size"] = 0
 
+	// 100 is the default max result size limit (per bucket) for top_hits aggregation
+	// This limit can be set by changing the [index.max_inner_result_window] index level setting.
+	// TODO: we should read this setting and set the limit accordingly
+	// A `bucket` here refers to a group of documents that match a certain clause/perdicate, and the top_hits aggregation can have multiple clauses/predicates
+	const TOP_HITS_MAX_BUCKET_RESULT_SIZE = 100
+
 	var filters []interface{}
 	if filter, ok := body["query"]; ok {
 		for _, variableSet := range variableSets {
@@ -28,14 +34,10 @@ func executeQueryWithVariables(variableSets []schema.QueryRequestVariablesElem, 
 
 	topHits := make(map[string]interface{})
 	topHits["_source"] = body["_source"]
-	topHits["size"] = 10
+	topHits["size"] = TOP_HITS_MAX_BUCKET_RESULT_SIZE
 	if size, ok := body["size"]; ok {
-		if (size.(int)) > 100 {
-			// 100 is the default max result size limit (per bucket) for top_hits aggregation
-			// This limit can be set by changing the [index.max_inner_result_window] index level setting. 
-			// TODO: we should read this setting and set the limit accordingly
-			// A `bucket` here refers to a group of documents that match a certain clause/perdicate, and the top_hits aggregation can have multiple clauses/predicates
-			topHits["size"] = 100
+		if (size.(int)) > TOP_HITS_MAX_BUCKET_RESULT_SIZE {
+			topHits["size"] = TOP_HITS_MAX_BUCKET_RESULT_SIZE
 		} else {
 			topHits["size"] = size
 		}

--- a/connector/variables.go
+++ b/connector/variables.go
@@ -30,7 +30,15 @@ func executeQueryWithVariables(variableSets []schema.QueryRequestVariablesElem, 
 	topHits["_source"] = body["_source"]
 	topHits["size"] = 10
 	if size, ok := body["size"]; ok {
-		topHits["size"] = size
+		if (size.(int)) > 100 {
+			// 100 is the default max result size limit (per bucket) for top_hits aggregation
+			// This limit can be set by changing the [index.max_inner_result_window] index level setting. 
+			// TODO: we should read this setting and set the limit accordingly
+			// A `bucket` here refers to a group of documents that match a certain clause/perdicate, and the top_hits aggregation can have multiple clauses/predicates
+			topHits["size"] = 100
+		} else {
+			topHits["size"] = size
+		}
 	}
 	if limit, ok := body["limit"]; ok {
 		topHits["from"] = limit


### PR DESCRIPTION
`top_hits` aggregation operator accepts a max size of `100` (by default). This PR sets max result size to 100 if size > 100. The `top_hits` aggregator is used primarily in for queries with variables, which are primarily used for remote relationships by the engine

Tests for this change are not a part of this PR. They will be added in a later PR.