### PR TITLE
add connector configuration to connector state

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -33,6 +33,7 @@ func (c *Connector) TryInitState(ctx context.Context, configuration *types.Confi
 		SupportedFilterFields:    make(map[string]interface{}),
 		NestedFields:             make(map[string]interface{}),
 		ElasticsearchInfo:        elasticsearchInfo.(map[string]interface{}),
+		Configuration:            configuration,
 	}
 
 	schema := ParseConfigurationToSchema(configuration, state)

--- a/connector/sort.go
+++ b/connector/sort.go
@@ -9,10 +9,10 @@ import (
 )
 
 // prepareSortQuery prepares the sort query.
-func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection string, configuration *types.Configuration) ([]map[string]interface{}, error) {
+func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection string) ([]map[string]interface{}, error) {
 	sort := make([]map[string]interface{}, len(orderBy.Elements))
 	for i, element := range orderBy.Elements {
-		sortElmnt, err := prepareSortElement(&element, state, collection, configuration)
+		sortElmnt, err := prepareSortElement(&element, state, collection)
 		if err != nil {
 			return nil, err
 		}
@@ -25,7 +25,7 @@ func prepareSortQuery(orderBy *schema.OrderBy, state *types.State, collection st
 //
 // It takes in the OrderByElement, state, and collection as parameters.
 // It returns the prepared sort element and an error if any.
-func prepareSortElement(element *schema.OrderByElement, state *types.State, collection string, configuration *types.Configuration) (map[string]interface{}, error) {
+func prepareSortElement(element *schema.OrderByElement, state *types.State, collection string) (map[string]interface{}, error) {
 	sort := make(map[string]interface{})
 	switch target := element.Target.Interface().(type) {
 	case *schema.OrderByColumn:
@@ -39,13 +39,13 @@ func prepareSortElement(element *schema.OrderByElement, state *types.State, coll
 			})
 		}
 
-		fieldType, fieldSubTypes, fieldDataEnabled, err := configuration.GetFieldProperties(collection, fieldPath)
+		fieldType, fieldSubTypes, fieldDataEnabled, err := state.Configuration.GetFieldProperties(collection, fieldPath)
 		if err != nil {
 			return nil, schema.InternalServerError("failed to get field types", map[string]any{"error": err.Error()})
 		}
 
 		if !internal.IsSortSupported(fieldType, fieldDataEnabled) {
-			// we iterate over the fieldSubTypes in reverse because the subtypes are sorted by priority. 
+			// we iterate over the fieldSubTypes in reverse because the subtypes are sorted by priority.
 			// We want to use the highest priority subType that is supported for sorting.
 			for i := len(fieldSubTypes) - 1; i >= 0; i-- {
 				subType := fieldSubTypes[i]

--- a/types/types.go
+++ b/types/types.go
@@ -38,7 +38,8 @@ func (c *Configuration) GetIndex(indexName string) (map[string]interface{}, erro
 	return index, nil
 }
 
-func (c *Configuration) GetFieldMap(indexName, fieldName string) (map[string]interface{}, error) {
+// returns the field object for the given field path from configuration
+func (c *Configuration) GetFieldMap(indexName, fieldPath string) (map[string]interface{}, error) {
 	index, err := c.GetIndex(indexName)
 	if err != nil {
 		return nil, err
@@ -49,12 +50,12 @@ func (c *Configuration) GetFieldMap(indexName, fieldName string) (map[string]int
 		return nil, fmt.Errorf("unable to find mapping in index: %s", indexName)
 	}
 
-	fieldPath := strings.Split(fieldName, ".")
+	splitFieldPath := strings.Split(fieldPath, ".")
 	curFieldPath := ""
 
 	fieldMap := make(map[string]interface{})
 
-	for i, curFieldName := range fieldPath {
+	for i, curFieldName := range splitFieldPath {
 		if i == 0 {
 			curFieldPath = curFieldName
 		} else {
@@ -77,8 +78,9 @@ func (c *Configuration) GetFieldMap(indexName, fieldName string) (map[string]int
 
 }
 
-func (c *Configuration) GetFieldProperties(indexName, fieldName string) (fieldType string, fieldSubTypes []string, fieldDataEnabled bool, err error) {
-	fieldMap, err := c.GetFieldMap(indexName, fieldName)
+// GetFieldProperties returns the field type, subtypes and field data enabled for the given field path.
+func (c *Configuration) GetFieldProperties(indexName, fieldPath string) (fieldType string, fieldSubTypes []string, fieldDataEnabled bool, err error) {
+	fieldMap, err := c.GetFieldMap(indexName, fieldPath)
 	if err != nil {
 		return "", nil, false, err
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -20,6 +20,7 @@ type State struct {
 	ElasticsearchInfo        map[string]interface{}
 	Schema                   *schema.SchemaResponse
 	NestedFields             map[string]interface{}
+	Configuration            *Configuration
 }
 
 // Configuration contains required settings for the connector.
@@ -64,7 +65,7 @@ func (c *Configuration) GetFieldMap(indexName, fieldName string) (map[string]int
 		if !ok {
 			return nil, fmt.Errorf("unable to find properties in index `%s` for field `%s`", indexName, curFieldPath)
 		}
-	
+
 		fieldMap, ok = properties[curFieldName].(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("unable to find field `%s` in index `%s` ", curFieldPath, indexName)
@@ -86,7 +87,7 @@ func (c *Configuration) GetFieldProperties(indexName, fieldName string) (fieldTy
 
 	fieldDataEnabled = internal.IsFieldDtaEnabled(fieldMap)
 
-	if (len(fieldsAndSubfields) == 1) {
+	if len(fieldsAndSubfields) == 1 {
 		return fieldsAndSubfields[0], make([]string, 0), fieldDataEnabled, nil
 	}
 

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -88,14 +88,14 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 		name          string
 		configuration string
 		indexName     string
-		fieldName     string
+		fieldPath     string
 		want          string
 	}{
 		{
 			name:          "transaction_customers_name",
 			configuration: configurationTransactions,
 			indexName:     "customers",
-			fieldName:     "name",
+			fieldPath:     "name",
 			want: `{
   "fields": {
     "keyword": {
@@ -110,7 +110,7 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 			name:          "transaction_payments_paymentStatus",
 			configuration: configurationTransactions,
 			indexName:     "payments",
-			fieldName:     "payment_status",
+			fieldPath:     "payment_status",
 			want: `{
   "type": "keyword"
 }`,
@@ -119,7 +119,7 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 			name:          "transaction_transactions_transactionDetails",
 			configuration: configurationTransactions,
 			indexName:     "transactions",
-			fieldName:     "transaction_details",
+			fieldPath:     "transaction_details",
 			want: `{
   "properties": {
     "currency": {
@@ -150,7 +150,7 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 			name:          "transaction_transactions_transactionDetails_itemName",
 			configuration: configurationTransactions,
 			indexName:     "transactions",
-			fieldName:     "transaction_details.item_name",
+			fieldPath:     "transaction_details.item_name",
 			want: `{
   "fields": {
     "keyword": {
@@ -165,7 +165,7 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 			name:          "transaction_transactions_transactionDetails_currency",
 			configuration: configurationTransactions,
 			indexName:     "transactions",
-			fieldName:     "transaction_details.currency",
+			fieldPath:     "transaction_details.currency",
 			want: `{
   "type": "keyword"
 }`,
@@ -176,7 +176,7 @@ func TestConfigurationGetFieldMap(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := getConfiguration(tt.configuration)
 
-			got, err := config.GetFieldMap(tt.indexName, tt.fieldName)
+			got, err := config.GetFieldMap(tt.indexName, tt.fieldPath)
 			assert.NoError(t, err)
 
 			gotJson, err := json.MarshalIndent(got, "", "  ")
@@ -192,7 +192,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 		name                 string
 		configuration        string
 		indexName            string
-		fieldName            string
+		fieldPath            string
 		wantFieldType        string
 		wantSubtypes         []string
 		wantFieldDataEnabled bool
@@ -201,7 +201,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 			name:                 "transaction_customers_name",
 			configuration:        configurationTransactions,
 			indexName:            "customers",
-			fieldName:            "name",
+			fieldPath:            "name",
 			wantFieldType:        "text",
 			wantSubtypes:         []string{"keyword"},
 			wantFieldDataEnabled: false,
@@ -210,7 +210,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 			name:                 "transaction_logs_log_level",
 			configuration:        configurationTransactions,
 			indexName:            "logs",
-			fieldName:            "log_level",
+			fieldPath:            "log_level",
 			wantFieldType:        "keyword",
 			wantSubtypes:         []string{},
 			wantFieldDataEnabled: false,
@@ -219,7 +219,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 			name:                 "transaction_transactions_transactionDetails_itemName",
 			configuration:        configurationTransactions,
 			indexName:            "transactions",
-			fieldName:            "transaction_details.item_name",
+			fieldPath:            "transaction_details.item_name",
 			wantFieldType:        "text",
 			wantSubtypes:         []string{"keyword"},
 			wantFieldDataEnabled: false,
@@ -228,7 +228,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 			name:                 "transaction_user_behavior_actions",
 			configuration:        configurationTransactions,
 			indexName:            "user_behavior",
-			fieldName:            "actions",
+			fieldPath:            "actions",
 			wantFieldType:        "nested",
 			wantSubtypes:         []string{},
 			wantFieldDataEnabled: false,
@@ -239,7 +239,7 @@ func TestConfigurationGetFieldProperties(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := getConfiguration(tt.configuration)
 
-			gotFieldType, gotFieldSubTypes, gotFieldDataEnabled, err := config.GetFieldProperties(tt.indexName, tt.fieldName)
+			gotFieldType, gotFieldSubTypes, gotFieldDataEnabled, err := config.GetFieldProperties(tt.indexName, tt.fieldPath)
 			assert.NoError(t, err)
 
 			assert.Equal(t, tt.wantFieldType, gotFieldType)


### PR DESCRIPTION
This is done because configuration contains the mappings of elasticsearch that contain additional information about fields that is not always present in the connector schema (for example, if a field is unindexed)