### PR TITLE
support queries using subfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Query clauses using subfields ([#44](https://github.com/hasura/ndc-elasticsearch/pull/44))
+
 ## [1.1.2]
 
 ### Changed

--- a/connector/filter.go
+++ b/connector/filter.go
@@ -199,7 +199,7 @@ func prepareNestedQuery(
 }
 
 // getCorrectFieldForOperator returns the best field or the `field.subtype` for the given operator.
-func getCorrectFieldForOperator(fieldPath, fieldType string, fieldSubTypes []string, bestTypesFamily map[string]bool) (bestField string, typeFound bool) {
+func getCorrectFieldForOperator(fieldPath, fieldType string, fieldSubTypes map[string]string, bestTypesFamily map[string]bool) (bestField string, typeFound bool) {
 	if bestTypesFamily[fieldType] {
 		// if the field type is in the best types family, return the field path
 		return fieldPath, true
@@ -208,9 +208,9 @@ func getCorrectFieldForOperator(fieldPath, fieldType string, fieldSubTypes []str
 		return fieldPath, false
 	} else if len(fieldSubTypes) > 0 {
 		// if the field has subtypes, return the first matching subfield appended to field path
-		for _, subType := range fieldSubTypes {
+		for subType, subField := range fieldSubTypes {
 			if bestTypesFamily[subType] {
-				return fmt.Sprintf("%s.%s", fieldPath, subType), true
+				return fmt.Sprintf("%s.%s", fieldPath, subField), true
 			}
 		}
 	}

--- a/connector/filter.go
+++ b/connector/filter.go
@@ -99,7 +99,7 @@ func handleExpressionBinaryComparisonOperator(
 	var bestFieldOrSubField string
 
 	// we need to check what type or subtype is best optimized for the operator, and use that type or subtype of the field
-	if internal.NumericalQuery[expr.Operator] {
+	if internal.NumericalQueries[expr.Operator] {
 		// this is a numerical query, optimized for numeric types
 		bestFieldOrSubField, bestFieldOrSubFieldFound = getCorrectFieldForOperator(fieldPath, fieldType, fieldSubTypes, internal.NumericFamilyOfTypes)
 	} else if internal.TermLevelQueries[expr.Operator] && !bestFieldOrSubFieldFound {

--- a/connector/query.go
+++ b/connector/query.go
@@ -32,6 +32,13 @@ func executeQuery(ctx context.Context, state *types.State, request *schema.Query
 	rowSets := make([]schema.RowSet, 0)
 	index := request.Collection
 
+	requestJson, err := json.MarshalIndent(request, "", "  ")
+    if err != nil {
+        fmt.Printf("Error marshalling ndc request to JSON: %v\n", err)
+    } else {
+        fmt.Printf("NDC Request: %s\n", string(requestJson))
+    }
+
 	// Identify the index from configuration
 	nativeQueries := state.Configuration.Queries
 	queryConfig, ok := nativeQueries[request.Collection]

--- a/connector/query.go
+++ b/connector/query.go
@@ -32,13 +32,6 @@ func executeQuery(ctx context.Context, state *types.State, request *schema.Query
 	rowSets := make([]schema.RowSet, 0)
 	index := request.Collection
 
-	requestJson, err := json.MarshalIndent(request, "", "  ")
-    if err != nil {
-        fmt.Printf("Error marshalling ndc request to JSON: %v\n", err)
-    } else {
-        fmt.Printf("NDC Request: %s\n", string(requestJson))
-    }
-
 	// Identify the index from configuration
 	nativeQueries := state.Configuration.Queries
 	queryConfig, ok := nativeQueries[request.Collection]

--- a/connector/query_test.go
+++ b/connector/query_test.go
@@ -93,11 +93,15 @@ var tests = []test{
 		group: "customers",
 		name:  "sort_by_subtype",
 	},
+	{
+		group: "customers",
+		name:  "simple_subtype_where_clause",
+	},
 }
 
 func TestPrepareElasticsearchQuery(t *testing.T) {
 	for _, tt := range tests {
-		t.Run(tt.group + "." + tt.name, func(t *testing.T) {
+		t.Run(tt.group+"."+tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			ctx = context.WithValue(ctx, "postProcessor", &types.PostProcessor{})
 			initTest(t, &tt)

--- a/connector/query_test.go
+++ b/connector/query_test.go
@@ -97,6 +97,10 @@ var tests = []test{
 		group: "customers",
 		name:  "simple_subtype_where_clause",
 	},
+	{
+		group: "customers",
+		name:  "subtype_term_clause",
+	},
 }
 
 func TestPrepareElasticsearchQuery(t *testing.T) {

--- a/connector/query_test.go
+++ b/connector/query_test.go
@@ -74,6 +74,10 @@ var tests = []test{
 		group: "payments",
 		name:  "simple_where_not_clause",
 	},
+	{
+		group: "payments",
+		name:  "simple_subtype_where_clause",
+	},
 }
 
 func TestPrepareElasticsearchQuery(t *testing.T) {

--- a/internal/static_types.go
+++ b/internal/static_types.go
@@ -434,3 +434,72 @@ var UnSupportedSortDataTypes = []string{
 	"range",
 	"_id",
 }
+
+// TermLevelQueries queries in elasticsearch for keyword family of types
+// more reading: https://www.elastic.co/guide/en/elasticsearch/reference/current/term-level-queries.html
+var TermLevelQueries = map[string]bool{
+	"exists":   true,
+	"fuzzy":    true,
+	"ids":      true,
+	"prefix":   true,
+	"range":    true,
+	"regexp":   true,
+	"term":     true,
+	"terms":    true,
+	"term_set": true,
+	"wildcard": true,
+}
+
+// range operations are optimzed for numeric types
+var NumericalQuery = map[string]bool{
+	"range": true,
+}
+
+// FullTextQueries queries in elasticsearch for text family of types
+// more reading: https://www.elastic.co/guide/en/elasticsearch/reference/current/full-text-queries.html
+var FullTextQueries = map[string]bool{
+	"intervals":           true,
+	"match":               true,
+	"match_bool_prefix":   true,
+	"match_phrase":        true,
+	"match_phrase_prefix": true,
+	"multi_match":         true,
+	"combined_fields":     true,
+	"query_string":        true,
+	"simple_query_string": true,
+}
+
+// Used for unstructured text, like the body of an email
+// more reading: https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
+var TextFamilyOfTypes = map[string]bool{
+	"text":            true,
+	"match_only_text": true,
+	"ip":              true,
+}
+
+// Used for structured content like email addresses, hostnames, status codes, zip codes or tags.
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html
+var KeywordFamilyOfTypes = map[string]bool{
+	"keyword":          true,
+	"constant_keyword": true,
+	"wildcard":         true,
+	"date":             true,
+	"date_nanos":       true,
+	"ip":               true,
+	"version":          true,
+}
+
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html
+var NumericFamilyOfTypes = map[string]bool{
+	"integer":       true,
+	"long":          true,
+	"short":         true,
+	"byte":          true,
+	"double":        true,
+	"float":         true,
+	"half_float":    true,
+	"unsigned_long": true,
+	"scaled_float":  true,
+	"date":          true,
+	"date_nanos":    true,
+}

--- a/internal/static_types.go
+++ b/internal/static_types.go
@@ -451,7 +451,7 @@ var TermLevelQueries = map[string]bool{
 }
 
 // range operations are optimzed for numeric types
-var NumericalQuery = map[string]bool{
+var NumericalQueries = map[string]bool{
 	"range": true,
 }
 

--- a/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/ndc_request.json
+++ b/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/ndc_request.json
@@ -1,0 +1,33 @@
+{
+  "arguments": {},
+  "collection": "customers",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "customerId": {
+        "column": "customer_id",
+        "type": "column"
+      },
+      "id": {
+        "column": "_id",
+        "type": "column"
+      },
+      "name": {
+        "column": "name",
+        "type": "column"
+      }
+    },
+    "predicate": {
+      "column": {
+        "type": "column",
+        "name": "name"
+      },
+      "operator": "prefix",
+      "type": "binary_comparison_operator",
+      "value": {
+        "type": "scalar",
+        "value": "J"
+      }
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/query.graphql
+++ b/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/query.graphql
@@ -1,0 +1,7 @@
+query MyQuery {
+  customers(where: {name: {prefix: "J"}}) {
+    id
+    customerId
+    name
+  }
+}

--- a/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/want.json
+++ b/testdata/unit_tests/query_tests/customers/simple_subtype_where_clause/want.json
@@ -1,0 +1,13 @@
+{
+  "_source": [
+    "_id",
+    "customer_id",
+    "name"
+  ],
+  "query": {
+    "prefix": {
+      "name.raw": "J"
+    }
+  },
+  "size": 10000
+}

--- a/testdata/unit_tests/query_tests/customers/subtype_term_clause/ndc_request.json
+++ b/testdata/unit_tests/query_tests/customers/subtype_term_clause/ndc_request.json
@@ -1,0 +1,25 @@
+{
+  "arguments": {},
+  "collection": "customers",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "name": {
+        "column": "name",
+        "type": "column"
+      }
+    },
+    "predicate": {
+      "column": {
+        "type": "column",
+        "name": "name"
+      },
+      "operator": "term",
+      "type": "binary_comparison_operator",
+      "value": {
+        "type": "scalar",
+        "value": "John"
+      }
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/customers/subtype_term_clause/query.graphql
+++ b/testdata/unit_tests/query_tests/customers/subtype_term_clause/query.graphql
@@ -1,0 +1,5 @@
+query MyQuery {
+  customers(where: {name: {term: "John"}}) {
+    name
+  }
+}

--- a/testdata/unit_tests/query_tests/customers/subtype_term_clause/want.json
+++ b/testdata/unit_tests/query_tests/customers/subtype_term_clause/want.json
@@ -1,0 +1,11 @@
+{
+  "_source": [
+    "name"
+  ],
+  "query": {
+    "term": {
+      "name.raw": "John"
+    }
+  },
+  "size": 10000
+}

--- a/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/ndc_request.json
+++ b/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/ndc_request.json
@@ -1,0 +1,33 @@
+{
+  "arguments": {},
+  "collection": "customers",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "customerId": {
+        "column": "customer_id",
+        "type": "column"
+      },
+      "id": {
+        "column": "_id",
+        "type": "column"
+      },
+      "name": {
+        "column": "name",
+        "type": "column"
+      }
+    },
+    "predicate": {
+      "column": {
+        "type": "column",
+        "name": "name"
+      },
+      "operator": "prefix",
+      "type": "binary_comparison_operator",
+      "value": {
+        "type": "scalar",
+        "value": "J"
+      }
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/query.graphql
+++ b/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/query.graphql
@@ -1,0 +1,7 @@
+query MyQuery {
+  customers(where: {name: {prefix: "J"}}) {
+    id
+    customerId
+    name
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/want.json
+++ b/testdata/unit_tests/query_tests/payments/simple_subtype_where_clause/want.json
@@ -1,0 +1,13 @@
+{
+  "_source": [
+    "_id",
+    "customer_id",
+    "name"
+  ],
+  "query": {
+    "prefix": {
+      "name.keyword": "J"
+    }
+  },
+  "size": 10000
+}


### PR DESCRIPTION
Completes [ENT-164](https://linear.app/hasura/issue/ENT-164/subtype-queries-not-working-prefix-operator-query-not-working)

This PR adds support for query generation using sub-fields. 

More reading on sub-fields: https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html