### PR TITLE
use `GetBestFieldOrSubFieldForQuery` for sorting

### DIFF
--- a/connector/sort.go
+++ b/connector/sort.go
@@ -1,8 +1,6 @@
 package connector
 
 import (
-	"fmt"
-
 	"github.com/hasura/ndc-elasticsearch/internal"
 	"github.com/hasura/ndc-elasticsearch/types"
 	"github.com/hasura/ndc-sdk-go/schema"
@@ -45,13 +43,8 @@ func prepareSortElement(element *schema.OrderByElement, state *types.State, coll
 		}
 
 		if !internal.IsSortSupported(fieldType, fieldDataEnabled) {
-			// since the type does not support sorting, we iterate over the subfields to find a subfield that does
-			for subFieldType, subField := range subFieldMap {
-				if internal.IsSortSupported(subFieldType, fieldDataEnabled) {
-					validField = fmt.Sprintf("%s.%s", validField, subField)
-					break
-				}
-			}
+			// since the type does not support sorting, we need to find the best subfield to sort on
+			validField, _ = internal.GetBestFieldOrSubFieldForQuery(fieldPath, fieldType, subFieldMap, "__sort")
 		}
 
 		fieldPath = validField

--- a/internal/static_types.go
+++ b/internal/static_types.go
@@ -448,6 +448,7 @@ var TermLevelQueries = map[string]bool{
 	"terms":    true,
 	"term_set": true,
 	"wildcard": true,
+	"__sort":   true, // __sort is a custom operator that represents sorting operation (this is *NOT* an elasticsearch operator)
 }
 
 var TermLevelAggregations = map[string]bool{
@@ -458,7 +459,8 @@ var TermLevelAggregations = map[string]bool{
 
 // range operations are optimzed for numeric types
 var NumericalQueries = map[string]bool{
-	"range": true,
+	"range":  true,
+	"__sort": true, // __sort is a custom operator that represents sorting operation (this is *NOT* an elasticsearch operator)
 }
 
 var NumericalAggregations = map[string]bool{


### PR DESCRIPTION
Child PR of #46 

This PR builds on top of the functions added in #46 and uses them for sort query generation