### PR TITLE
add index alias support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add index alias support ([#50](https://github.com/hasura/ndc-elasticsearch/pull/50))
+
 ## [1.1.3]
 
 ### Changed

--- a/cli/update.go
+++ b/cli/update.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"path/filepath"
 
 	"github.com/hasura/ndc-elasticsearch/connector"
@@ -36,10 +35,13 @@ func updateConfig(ctx context.Context, configDir string) error {
 	}
 
 	// Get aliases for indices and add them to mappings.
-	_, err = client.GetAliases(ctx, mappings)
+	aliasToIndexMap, err := client.GetAliases(ctx)
 	if err != nil {
 		return err
 	}
+
+	// Add aliases to mappings.
+	client.AddAliasesToMappings(ctx, aliasToIndexMap, mappings)
 
 	configPath := filepath.Join(configDir, ConfigFileName)
 
@@ -62,7 +64,7 @@ func updateConfig(ctx context.Context, configDir string) error {
 // It reads the existing configuration file if it exists, or creates a new one with an empty "queries" field.
 // It then overwrites the "indices" field with the provided mappings.
 // Returns the JSON data as a byte array and any error encountered.
-func marshalMappings(configPath string, mappings interface{}) ([]byte, error) {
+func marshalMappings(configPath string, mappings map[string]interface{}) ([]byte, error) {
 	// Define the initial configuration template.
 	configuration := &types.Configuration{
 		Indices: make(map[string]interface{}),
@@ -78,11 +80,7 @@ func marshalMappings(configPath string, mappings interface{}) ([]byte, error) {
 		}
 	}
 	// Overwrite the "indices" field with the provided mappings.
-	indices, ok := mappings.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to convert mappings to map[string]interface{}")
-	}
-	configuration.Indices = indices
+	configuration.Indices = mappings
 
 	// Marshal the configuration data into a JSON byte array with indentation.
 	return json.MarshalIndent(configuration, "", "  ")

--- a/cli/update.go
+++ b/cli/update.go
@@ -35,6 +35,12 @@ func updateConfig(ctx context.Context, configDir string) error {
 		return err
 	}
 
+	// Get aliases for indices and add them to mappings.
+	_, err = client.GetAliases(ctx, mappings)
+	if err != nil {
+		return err
+	}
+
 	configPath := filepath.Join(configDir, ConfigFileName)
 
 	// Marshal the mappings into a JSON configuration file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,8 +17,18 @@ See also: [development instructions](./development.md)
 
 ## Index mappings
 
-Index mappings are added by introspecting the Elasticsearch provided during update of the configuration directory.
+Index mappings are added by introspecting the Elasticsearch database provided during update of the configuration directory.
 These mappings are similar to what we get in [Elasticsearch's mappings API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html).
+
+## Index aliases
+
+Index aliases are added by intropsecting the Elasticsearch database during the update of the configuration directory. Aliases for an index are added as separate indexes in the `indices` key of the `configuration.json` file, with the mappings of the original index copied to them.
+
+More reading on Elasticsearch index aliases: https://www.elastic.co/guide/en/elasticsearch/reference/current/aliases.html
+
+> **NOTE** 
+>
+> If you change an alias in a way that changes its underlying mappings, please re-introspect the datasource to get the updated mappings for the alias.
 
 ## Native Queries
 


### PR DESCRIPTION
Completes [ENT-128](https://linear.app/hasura/issue/ENT-128/add-aliases-to-introspection)

This PR adds support for index aliases.
More reading on aliases in Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/current/aliases.html

## Implementation
Each alias is added as a separate index in `configuration.json` file. This means, the connector will treat each alias as its own index. The alias is given the same mappings as that of the original index.

## Review the PR
- The fix is in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/50/commits/0e140faa1d48c95b72bedaa5b37bffe62235416b)
- The [refactor commit](https://github.com/hasura/ndc-elasticsearch/pull/50/commits/44338c720325eeac22a7e37ce145d43629f4c2bb) cleans up the fix
- Documentation is updated in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/50/commits/396b3bad454a26ffdbc2abd90766fa873c96da8c)

---
**NOTE**
There are no tests for this change currently, because simple unit tests cannot properly test this change. This change requires an Elasticsearch database to be running and accessible by the connector. A test suite that deploys a test db is a WiP currently.