### PR TITLE
Implement `search_after` operator for pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for `search_after` in pagination ([#52](https://github.com/hasura/ndc-elasticsearch/pull/52))
+
 ## [1.2.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add support for `search_after` in pagination ([#52](https://github.com/hasura/ndc-elasticsearch/pull/52))
+
+### Changed
+
+- Surface query errors in GraphQL Query response ([#52](https://github.com/hasura/ndc-elasticsearch/pull/52))
 
 ## [1.2.0]
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Below, you'll find a matrix of all supported features for the Elasticsearch conn
 | Filter / Search                 | ✅        |       |
 | Simple Aggregation              | alpha\*   |       |
 | Sort                            | ✅        |       |
-| Paginate                        | ✅\*        |       |
+| Paginate                        | ✅        |       |
 | Relationships                   | ✅\*      |       |
 | Nested Objects                  | ✅        |       |
 | Nested Arrays                   | ✅        |       |
@@ -46,7 +46,6 @@ Below, you'll find a matrix of all supported features for the Elasticsearch conn
 
 > [!Note]
 > - **Relationships** are currently implemented via `top_hits` operator. That operator has a default maximum result size limit of 100 rows. This is what the connector operates on. If you give the connector a higher limit, it will change that to 100 for compliance with the database. Also, since the returned result will contain only 100 rows per bucket, it may not represent the whole result.
->- **Pagination** currently works only upto 10,000 rows because of the limits that Elasticsearch imposes. Pagination for additional rows will be available in a future relase version.
 
 > [!Note]
 > Aggregations are currently in alpha and are being actively worked upon

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ ddn connector-link add-resources <connector-name>
 
 This command will track all the indices in your Elasticsearch DB as [Models](https://hasura.io/docs/3.0/supergraph-modeling/models).
 
+## Detailed Documentation
+
+Please checkout out the [detailed documentation](./docs/documentation.md).
+
 ## Contributing
 
 Check out our [contributing guide](./docs/contributing.md) for more details.

--- a/connector/query.go
+++ b/connector/query.go
@@ -26,6 +26,15 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
 
 // executeQuery prepares equivalent elasticsearch query, executes it and returns the ndc response.
 func executeQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, span trace.Span) (schema.QueryResponse, error) {
+
+	// uncomment to pretty print the query as JSON
+	// requestJson, err := json.MarshalIndent(request, "", "  ")
+	// if err != nil {
+	// 	fmt.Printf("Error marshalling request to JSON: %v\n", err)
+	// } else {
+	// 	fmt.Printf("request: %s\n\n", string(requestJson))
+	// }
+
 	// Set the postProcessor in ctx
 	ctx = context.WithValue(ctx, "postProcessor", &types.PostProcessor{})
 	logger := connector.GetLogger(ctx)

--- a/connector/query.go
+++ b/connector/query.go
@@ -96,7 +96,9 @@ func executeQuery(ctx context.Context, state *types.State, request *schema.Query
 	res, err := state.Client.Search(searchContext, index, dslQuery)
 	if err != nil {
 		searchSpan.SetStatus(codes.Error, err.Error())
-		return nil, err
+		return nil, schema.UnprocessableContentError("failed to execute query", map[string]any{
+			"error": err.Error(),
+		})
 	}
 	searchSpan.End()
 

--- a/connector/query_test.go
+++ b/connector/query_test.go
@@ -129,6 +129,18 @@ var tests = []test{
 		group: "payments",
 		name:  "subfield_cardinality_aggregation",
 	},
+	{
+		group: "payments",
+		name:  "search_after",
+	},
+	{
+		group: "payments",
+		name:  "search_after_with_query",
+	},
+	{
+		group: "payments",
+		name:  "search_after_multiple_sorts",
+	},
 }
 
 func TestPrepareElasticsearchQuery(t *testing.T) {

--- a/connector/schema.go
+++ b/connector/schema.go
@@ -3,9 +3,9 @@ package connector
 import (
 	"context"
 
+	"github.com/hasura/ndc-elasticsearch/internal"
 	"github.com/hasura/ndc-elasticsearch/types"
 	"github.com/hasura/ndc-sdk-go/schema"
-	"github.com/hasura/ndc-elasticsearch/internal"
 )
 
 // GetSchema returns the schema by parsing the configuration.
@@ -53,7 +53,7 @@ func ParseConfigurationToSchema(configuration *types.Configuration, state *types
 
 		ndcSchema.Collections = append(ndcSchema.Collections, schema.CollectionInfo{
 			Name:                  indexName,
-			Arguments:             schema.CollectionInfoArguments{},
+			Arguments:             internal.CollectionArgumentsMap,
 			Type:                  indexName,
 			UniquenessConstraints: schema.CollectionInfoUniquenessConstraints{},
 			ForeignKeys:           schema.CollectionInfoForeignKeys{},

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,10 +4,10 @@
 Pagination is supported via the `offset` operator and the `search_after` operator.
 
 ### `offset`
-The `offset` operator can be used if the sum of page size (`limit`) and the `offset` value is less than or equal to 10,000. This is a restriction imposed by Elasticsearch. For paginating further, please use the `search_after` operator
+The `offset` operator can be used if the sum of page size (`limit`) and the `offset` value is less than or equal to the value of [`index.max_result_window`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-result-window) (defaults to 10,000). This is a restriction imposed by Elasticsearch. For paginating further, please use the `search_after` operator
 
 ### `search_after`
-The `search_after` operator can be used to page more than 10,000 results. The `search_after` operator exposed in GraphQL queries is functionally and syntactically similar to the `search_after` operator in the Elasticsearch. It expects an array of sort values as its argument ([read more about `search_after` in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after)).
+The `search_after` operator can be used to page more than [`index.max_result_window`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-result-window) (default: 10,000) results. The `search_after` operator exposed in GraphQL queries is functionally and syntactically similar to the `search_after` operator in the Elasticsearch. It expects an array of sort values as its argument ([read more about `search_after` in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after)).
 
 Please note the following requirements for correctly using the `search_after` operator:
 1. Any query using the `search_after` operator must also include the `order_by` clause

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,42 @@
+# Documentation
+
+## Pagination
+Pagination is supported via the `offset` operator and the `search_after` operator.
+
+### `offset`
+The `offset` operator can be used if the sum of page size (`limit`) and the `offset` value is less than or equal to 10,000. This is a restriction imposed by Elasticsearch. For paginating further, please use the `search_after` operator
+
+### `search_after`
+The `search_after` operator can be used to page more than 10,000 results. The `search_after` operator exposed in GraphQL queries is functionally and syntactically similar to the `search_after` operator in the Elasticsearch. It expects an array of sort values as its argument ([read more about `search_after` in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after)).
+
+Please note the following requirements for correctly using the `search_after` operator:
+1. Any query using the `search_after` operator must also include the `order_by` clause
+2. The order of elements in `search_after` should be identical to the order of corresponding fields in `order_by`. For example, consider a model that has got the fields `email` and `customerId` and you want to sort by both. The correct values would be 
+
+```graphql
+order_by: [
+  {customerId: Asc}, 
+  {email: Asc}
+], 
+args: {
+  searchAfter: [
+    "cust005", 
+    "cust_5@abc.xyz"
+  ]
+}
+```
+
+and, the incorrect way would be 
+
+```graphql
+order_by: [
+  {customerId: Asc}, 
+  {email: Asc}
+], 
+args: {
+  searchAfter: [ // the order of elements is not the same as the order of fields in order_by
+    "cust_5@abc.xyz",
+    "cust005", 
+  ]
+}
+```

--- a/internal/static_types.go
+++ b/internal/static_types.go
@@ -132,6 +132,11 @@ var ScalarTypeMap = map[string]schema.ScalarType{
 		ComparisonOperators: getComparisonOperatorDefinition("token_count"),
 		Representation:      schema.NewTypeRepresentationInteger().Encode(),
 	},
+	"json": {
+		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
+		ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
+		Representation:      schema.NewTypeRepresentationJSON().Encode(),
+	},
 }
 
 // typePriorityMap is a map of data types and their priority for sorting.
@@ -173,6 +178,7 @@ var RequiredScalarTypes = map[string]schema.ScalarType{
 	"float":   ScalarTypeMap["float"],
 	"keyword": ScalarTypeMap["keyword"],
 	"long":    ScalarTypeMap["long"],
+	"json":    ScalarTypeMap["json"],
 }
 
 var RequiredObjectTypes = map[string]schema.ObjectType{
@@ -333,6 +339,15 @@ var ObjectTypeMap = map[string]schema.ObjectType{
 }
 
 var UnsupportedRangeQueryScalars = []string{"binary", "completion", "_id", "wildcard", "match_only_text", "search_as_you_type"}
+
+var CollectionArgumentsMap = map[string]schema.ArgumentInfo{
+	// used for paginating more than 10,000 results
+	// https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after
+	"search_after": {
+		Type:        schema.NewNullableNamedType("json").Encode(),
+		Description: utils.ToPtr(`(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.`),
+	},
+}
 
 // getComparisonOperatorDefinition generates and returns a map of comparison operators based on the provided data type.
 func getComparisonOperatorDefinition(dataType string) map[string]schema.ComparisonOperatorDefinition {

--- a/testdata/unit_tests/fields_tests/books/want_schema.json
+++ b/testdata/unit_tests/fields_tests/books/want_schema.json
@@ -1,7 +1,18 @@
 {
   "collections": [
     {
-      "arguments": {},
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
       "foreign_keys": {},
       "name": "my_book_index",
       "type": "my_book_index",
@@ -598,6 +609,13 @@
       },
       "representation": {
         "type": "integer"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
       }
     },
     "keyword": {

--- a/testdata/unit_tests/fields_tests/books_2/want_schema.json
+++ b/testdata/unit_tests/fields_tests/books_2/want_schema.json
@@ -1,7 +1,18 @@
 {
   "collections": [
     {
-      "arguments": {},
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
       "foreign_keys": {},
       "name": "my_book_index",
       "type": "my_book_index",
@@ -598,6 +609,13 @@
       },
       "representation": {
         "type": "integer"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
       }
     },
     "keyword": {

--- a/testdata/unit_tests/fields_tests/identification/want_schema.json
+++ b/testdata/unit_tests/fields_tests/identification/want_schema.json
@@ -1,7 +1,18 @@
 {
   "collections": [
     {
-      "arguments": {},
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
       "foreign_keys": {},
       "name": "indentification",
       "type": "indentification",
@@ -508,6 +519,13 @@
       },
       "representation": {
         "type": "integer"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
       }
     },
     "keyword": {

--- a/testdata/unit_tests/query_tests/payments/search_after/ndc_request.json
+++ b/testdata/unit_tests/query_tests/payments/search_after/ndc_request.json
@@ -1,0 +1,36 @@
+{
+  "arguments": {
+    "search_after": {
+      "type": "literal",
+      "value": [
+        102.4
+      ]
+    }
+  },
+  "collection": "metrics",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "metricType": {
+        "column": "metric_type",
+        "type": "column"
+      },
+      "metricValue": {
+        "column": "metric_value",
+        "type": "column"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "metric_value",
+            "path": [],
+            "type": "column"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after/query.graphql
+++ b/testdata/unit_tests/query_tests/payments/search_after/query.graphql
@@ -1,0 +1,6 @@
+query MyQuery {
+  metrics(args: {searchAfter: [102.4]}, order_by: {metricValue: Asc}) {
+    metricType
+    metricValue
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after/want.json
+++ b/testdata/unit_tests/query_tests/payments/search_after/want.json
@@ -1,0 +1,17 @@
+{
+  "_source": [
+    "metric_type",
+    "metric_value"
+  ],
+  "search_after": [
+    102.4
+  ],
+  "size": 10000,
+  "sort": [
+    {
+      "metric_value": {
+        "order": "asc"
+      }
+    }
+  ]
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/ndc_request.json
+++ b/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/ndc_request.json
@@ -1,0 +1,67 @@
+{
+  "arguments": {
+    "search_after": {
+      "type": "literal",
+      "value": [
+        78.1,
+        "CPU Usage",
+        "%"
+      ]
+    }
+  },
+  "collection": "metrics",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "id": {
+        "column": "_id",
+        "type": "column"
+      },
+      "metricType": {
+        "column": "metric_type",
+        "type": "column"
+      },
+      "metricUnit": {
+        "column": "metric_unit",
+        "type": "column"
+      },
+      "metricValue": {
+        "column": "metric_value",
+        "type": "column"
+      },
+      "timestamp": {
+        "column": "timestamp",
+        "type": "column"
+      }
+    },
+    "limit": 3,
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "metric_value",
+            "path": [],
+            "type": "column"
+          }
+        },
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "metric_type",
+            "path": [],
+            "type": "column"
+          }
+        },
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "metric_unit",
+            "path": [],
+            "type": "column"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/query.graphql
+++ b/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/query.graphql
@@ -1,0 +1,12 @@
+query MyQuery {
+  metrics(
+    args: {searchAfter: [78.1, "CPU Usage", "%"]}
+    order_by: [{metricValue: Asc}, {metricType: Asc}, {metricUnit: Asc}]
+  ) {
+    id
+    metricType
+    metricUnit
+    metricValue
+    timestamp
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/want.json
+++ b/testdata/unit_tests/query_tests/payments/search_after_multiple_sorts/want.json
@@ -1,0 +1,32 @@
+{
+  "_source": [
+    "_id",
+    "metric_type",
+    "metric_unit",
+    "metric_value",
+    "timestamp"
+  ],
+  "search_after": [
+    78.1,
+    "CPU Usage",
+    "%"
+  ],
+  "size": 3,
+  "sort": [
+    {
+      "metric_value": {
+        "order": "asc"
+      }
+    },
+    {
+      "metric_type": {
+        "order": "asc"
+      }
+    },
+    {
+      "metric_unit": {
+        "order": "asc"
+      }
+    }
+  ]
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_with_query/ndc_request.json
+++ b/testdata/unit_tests/query_tests/payments/search_after_with_query/ndc_request.json
@@ -1,0 +1,48 @@
+{
+  "arguments": {
+    "search_after": {
+      "type": "literal",
+      "value": [
+        72.5
+      ]
+    }
+  },
+  "collection": "metrics",
+  "collection_relationships": {},
+  "query": {
+    "fields": {
+      "metricType": {
+        "column": "metric_type",
+        "type": "column"
+      },
+      "metricValue": {
+        "column": "metric_value",
+        "type": "column"
+      }
+    },
+    "order_by": {
+      "elements": [
+        {
+          "order_direction": "asc",
+          "target": {
+            "name": "metric_value",
+            "path": [],
+            "type": "column"
+          }
+        }
+      ]
+    },
+    "predicate": {
+      "column": {
+        "type": "column",
+        "name": "metric_type"
+      },
+      "operator": "prefix",
+      "type": "binary_comparison_operator",
+      "value": {
+        "type": "scalar",
+        "value": "CPU"
+      }
+    }
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_with_query/query.graphql
+++ b/testdata/unit_tests/query_tests/payments/search_after_with_query/query.graphql
@@ -1,0 +1,10 @@
+query MyQuery {
+  metrics(
+    args: {searchAfter: [72.5]}
+    order_by: {metricValue: Asc}
+    where: {metricType: {prefix: "CPU"}}
+  ) {
+    metricType
+    metricValue
+  }
+}

--- a/testdata/unit_tests/query_tests/payments/search_after_with_query/want.json
+++ b/testdata/unit_tests/query_tests/payments/search_after_with_query/want.json
@@ -1,0 +1,22 @@
+{
+  "_source": [
+    "metric_type",
+    "metric_value"
+  ],
+  "query": {
+    "prefix": {
+      "metric_type": "CPU"
+    }
+  },
+  "search_after": [
+    72.5
+  ],
+  "size": 10000,
+  "sort": [
+    {
+      "metric_value": {
+        "order": "asc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Completes [ENT-228](https://linear.app/hasura/issue/ENT-228/add-support-for-search-after-operator)

### Design

`search_after` has been added as an argument to all collections

### Review
- Tests for queries with `search_after` are added in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/52/commits/b7cb227a89c53f6c2e84924cf6cbed73a72dcc8b). Please review the test cases (GQL queries) and the resulting Elasticsearch queries (`want.json`) to verify they're correct
- Code implementation for query generation of `search_after` is in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/52/commits/1e72cfa9d6e05fc8d6d3ac6e61e69c59cd57eeb4)
- `search_after` being added as a collection argument and the resulting changes in the `/schema` of the connector can be reviewed in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/52/commits/a525af79f2104164606ee972a638acfd13be04c1)
- Documentation is in [this commit](https://github.com/hasura/ndc-elasticsearch/pull/52/commits/a08ce9f3dc1218853ebe30a6d90059846ab660c3)
