### PR TITLE
implement query explain for elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `/query/explain` endpoint ([#57](https://github.com/hasura/ndc-elasticsearch/pull/57))
+
 ## [1.3.0]
 
 ### Added

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -68,11 +68,6 @@ func (c *Connector) GetCapabilities(configuration *types.Configuration) schema.C
 	}
 }
 
-// QueryExplain explains a query by creating an execution plan.
-func (c *Connector) QueryExplain(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (*schema.ExplainResponse, error) {
-	return nil, schema.NotSupportedError("query explain has not been supported yet", nil)
-}
-
 // MutationExplain explains a mutation by creating an execution plan.
 func (c *Connector) MutationExplain(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.MutationRequest) (*schema.ExplainResponse, error) {
 	return nil, schema.NotSupportedError("mutation explain has not been supported yet", nil)

--- a/connector/query_explain.go
+++ b/connector/query_explain.go
@@ -1,0 +1,93 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hasura/ndc-elasticsearch/types"
+	"github.com/hasura/ndc-sdk-go/connector"
+	"github.com/hasura/ndc-sdk-go/schema"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func (c *Connector) QueryExplain(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (*schema.ExplainResponse, error) {
+	span := trace.SpanFromContext(ctx)
+	response, err := executeQueryExplainRequest(ctx, state, request, span)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+	return response, nil
+}
+
+func executeQueryExplainRequest(ctx context.Context, state *types.State, request *schema.QueryRequest, span trace.Span) (*schema.ExplainResponse, error) {
+	ctx = context.WithValue(ctx, "postProcessor", &types.PostProcessor{})
+	logger := connector.GetLogger(ctx)
+	index := request.Collection
+
+	prepareContext, prepareSpan := state.Tracer.Start(ctx, "prepare_elasticsearch_query_explain")
+	defer prepareSpan.End()
+
+	dslQuery, err := prepareElasticsearchQuery(prepareContext, request, state, index)
+	if err != nil {
+		prepareSpan.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	// Prepare query with variables if present
+	if len(request.Variables) != 0 {
+		_, variableSpan := state.Tracer.Start(ctx, "prepare_query_explain_with_variables")
+		defer variableSpan.End()
+
+		addSpanEvent(variableSpan, logger, "prepare_query_explain_with_variables", map[string]any{
+			"variables": request.Variables,
+		})
+		dslQuery, err = executeQueryWithVariables(request.Variables, dslQuery)
+		if err != nil {
+			variableSpan.SetStatus(codes.Error, err.Error())
+			return nil, err
+		}
+		variableSpan.End()
+	}
+
+	// Execute the elasticsearch query
+	searchContext, searchSpan := state.Tracer.Start(ctx, "database_request")
+	defer searchSpan.End()
+
+	queryJson, _ := json.Marshal(dslQuery)
+	setDatabaseAttribute(span, state, index, string(queryJson))
+	addSpanEvent(searchSpan, logger, "search_elasticsearch", map[string]any{
+		"elasticsearch_request": dslQuery,
+	})
+	res, err := state.Client.ExplainSearch(searchContext, index, dslQuery)
+
+	if err != nil {
+		searchSpan.SetStatus(codes.Error, err.Error())
+		return nil, schema.UnprocessableContentError("failed to execute query", map[string]any{
+			"error": err.Error(),
+		})
+	}
+	searchSpan.End()
+
+	prettyQueryJson, err := json.MarshalIndent(dslQuery, "", "  ")
+	if err != nil {
+		return nil, schema.UnprocessableContentError("failed to marshal query to JSON", map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	prettyResponseJson, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return nil, schema.UnprocessableContentError("failed to marshal response to JSON", map[string]any{
+			"error": err.Error(),
+		})
+	}
+
+	return &schema.ExplainResponse{
+		Details: schema.ExplainResponseDetails{
+			"query_profile": string(prettyResponseJson),
+			"query":         string(prettyQueryJson),
+		},
+	}, nil
+}

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -40,3 +40,7 @@ args: {
   ]
 }
 ```
+
+## `/query/explain`
+
+NDC Elasticsearch supports the [`/query/explain` endpoint from the NDC Spec](https://hasura.github.io/ndc-spec/specification/explain.html) using Elasticsearch's [Search Profile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html). Elasticsearch's [Search Explain API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html) is not used because it requires a document ID, which is not avaialble at the time of query.


### PR DESCRIPTION
Implements `/query/explain` for NDC Elasticsearch with the following caveats:
1. The [explain API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html) in Elasticsearch requires a document ID to work, which is not available to NDC Elasticsearch, and therefore it is not used.
2. The next best thing is [profile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html). `/explain/query` in NDC Elasticsearch is implemented using this.

Completes [ENT-255](https://linear.app/hasura/issue/ENT-255/add-explain-support-for-elasticsearch)

## Tests

Testing this change requires an e2e test setup with the Elasticsearch Database reachable. A framework that supports these kinds of tests is a WiP.

## Examples

### Example NDC Request
```json
{
  "arguments": {},
  "collection": "customers",
  "collection_relationships": {},
  "query": {
    "fields": {
      "id": {
        "column": "_id",
        "type": "column"
      },
      "name": {
        "column": "name",
        "type": "column"
      }
    }
  }
}
```

### Example response from the Elasticsearch Profile API
```json
{
  "_shards": {
    "failed": 0,
    "skipped": 0,
    "successful": 1,
    "total": 1
  },
  "hits": {
    "hits": [
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "1",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "John Doe"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "2",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Jane Smith"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "3",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Alice Johnson"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "4",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Bob Brown"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "5",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Charlie Davis"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "6",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "John Smith"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "7",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Jane Doe"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "8",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Jane Johnson"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "9",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "John Brown"
        }
      },
      {
        "_explanation": {
          "description": "*:*",
          "details": [],
          "value": 1
        },
        "_id": "10",
        "_index": "customers",
        "_node": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "_score": 1,
        "_shard": "[customers][0]",
        "_source": {
          "name": "Charlie Davis"
        }
      }
    ],
    "max_score": 1,
    "total": {
      "relation": "eq",
      "value": 10
    }
  },
  "profile": {
    "shards": [
      {
        "aggregations": [],
        "cluster": "(local)",
        "fetch": {
          "breakdown": {
            "load_source": 15834,
            "load_source_count": 10,
            "load_stored_fields": 242041,
            "load_stored_fields_count": 10,
            "next_reader": 135000,
            "next_reader_count": 1
          },
          "children": [
            {
              "breakdown": {
                "next_reader": 250,
                "next_reader_count": 1,
                "process": 171043,
                "process_count": 10
              },
              "description": "",
              "time_in_nanos": 171293,
              "type": "ExplainPhase"
            },
            {
              "breakdown": {
                "next_reader": 81750,
                "next_reader_count": 1,
                "process": 85248,
                "process_count": 10
              },
              "description": "",
              "time_in_nanos": 166998,
              "type": "FetchFieldsPhase"
            },
            {
              "breakdown": {
                "next_reader": 125,
                "next_reader_count": 1,
                "process": 377207,
                "process_count": 10
              },
              "debug": {
                "fast_path": 0
              },
              "description": "",
              "time_in_nanos": 377332,
              "type": "FetchSourcePhase"
            },
            {
              "breakdown": {
                "next_reader": 250,
                "next_reader_count": 1,
                "process": 3377,
                "process_count": 10
              },
              "description": "",
              "time_in_nanos": 3627,
              "type": "StoredFieldsPhase"
            }
          ],
          "debug": {
            "stored_fields": [
              "_id",
              "_routing",
              "_source"
            ]
          },
          "description": "",
          "time_in_nanos": 1373583,
          "type": "fetch"
        },
        "id": "[qP1S9XrGQ6-s_ZnURCi5sQ][customers][0]",
        "index": "customers",
        "node_id": "qP1S9XrGQ6-s_ZnURCi5sQ",
        "searches": [
          {
            "collector": [
              {
                "children": [
                  {
                    "name": "SimpleTopScoreDocCollector",
                    "reason": "search_top_hits",
                    "time_in_nanos": 13084
                  }
                ],
                "name": "QueryPhaseCollector",
                "reason": "search_query_phase",
                "time_in_nanos": 17666
              }
            ],
            "query": [
              {
                "breakdown": {
                  "advance": 0,
                  "advance_count": 0,
                  "build_scorer": 6001,
                  "build_scorer_count": 2,
                  "compute_max_score": 0,
                  "compute_max_score_count": 0,
                  "count_weight": 0,
                  "count_weight_count": 0,
                  "create_weight": 2125,
                  "create_weight_count": 1,
                  "match": 0,
                  "match_count": 0,
                  "next_doc": 1416,
                  "next_doc_count": 11,
                  "score": 668,
                  "score_count": 10,
                  "set_min_competitive_score": 0,
                  "set_min_competitive_score_count": 0,
                  "shallow_advance": 0,
                  "shallow_advance_count": 0
                },
                "description": "*:*",
                "time_in_nanos": 10210,
                "type": "MatchAllDocsQuery"
              }
            ],
            "rewrite_time": 3500
          }
        ],
        "shard_id": 0
      }
    ]
  },
  "timed_out": false,
  "took": 3
}
```