### PR TITLE
add bearer token support for authorization to credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for Bearer Token in credentials provider ([#78](https://github.com/hasura/ndc-elasticsearch/pull/78))
+
 ## [1.6.0]
 
 - DDN workspace support

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -16,4 +16,4 @@ To use credentials provider, only set the `ELASTICSEARCH_URL` env var when using
 | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | HASURA_CREDENTIALS_PROVIDER_URI              | The webhook URI for the auth service                                                                                         |
 | ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY       | This is the key for the credentials provider                                                                                 |
-| ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM | This is the security credential that is expected from the credential provider service. Could be `api-key` or `service-token` |
+| ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM | This is the security credential that is expected from the credential provider service. Could be `api-key` or `service-token` or `bearer-token` |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -12,8 +12,8 @@ If you have an auth service that can provide credentials to NDC Elasticsearch, y
 
 To use credentials provider, only set the `ELASTICSEARCH_URL` env var when using `ddn connector init -i`. After that, once the connector is initialized, set up the following env vars using the command `ddn connector env add $my-connector --env $NEW_VAR=$value`
 
-| Env Var                                      | Description                                                                                                                  |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| HASURA_CREDENTIALS_PROVIDER_URI              | The webhook URI for the auth service                                                                                         |
-| ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY       | This is the key for the credentials provider                                                                                 |
+| Env Var                                      | Description                                                                                                                                    |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| HASURA_CREDENTIALS_PROVIDER_URI              | The webhook URI for the auth service                                                                                                           |
+| ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY       | This is the key for the credentials provider                                                                                                   |
 | ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM | This is the security credential that is expected from the credential provider service. Could be `api-key` or `service-token` or `bearer-token` |

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -16,16 +16,16 @@ const esMaxResultSize = 10000
 const DEFAULT_RESULT_SIZE_KEY = "esDefaultResultSize"
 
 var (
-	credentailsProviderKeyEnvVar       = "ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY"
-	credentailsProviderMechanismEnvVar = "ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM"
+	credentialsProviderKeyEnvVar       = "ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY"
+	credentialsProviderMechanismEnvVar = "ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM"
 	credentialsProviderUri             = "HASURA_CREDENTIALS_PROVIDER_URI"
 	elasticsearchUrl                   = "ELASTICSEARCH_URL"
 )
 
 var (
-	errCredentialProviderKeyNotSet        = fmt.Errorf("%s is not set", credentailsProviderKeyEnvVar)
-	errCredentialProviderMechanismNotSet  = fmt.Errorf("%s is not set", credentailsProviderMechanismEnvVar)
-	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"api-key\" or \"service-token\" or \"bearer-token\"", credentailsProviderMechanismEnvVar)
+	errCredentialProviderKeyNotSet        = fmt.Errorf("%s is not set", credentialsProviderKeyEnvVar)
+	errCredentialProviderMechanismNotSet  = fmt.Errorf("%s is not set", credentialsProviderMechanismEnvVar)
+	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"api-key\" or \"service-token\" or \"bearer-token\"", credentialsProviderMechanismEnvVar)
 	errElasticsearchUrlNotSet             = fmt.Errorf("%s is not set", elasticsearchUrl)
 )
 
@@ -72,18 +72,18 @@ func getConfigFromCredentialsProvider(ctx context.Context, forceRefresh bool) (*
 		return nil, err
 	}
 
-	key := os.Getenv(credentailsProviderKeyEnvVar)
-	mechanism := os.Getenv(credentailsProviderMechanismEnvVar)
-	err = setupCredentailsUsingCredentialsProvider(ctx, esConfig, key, mechanism, forceRefresh)
+	key := os.Getenv(credentialsProviderKeyEnvVar)
+	mechanism := os.Getenv(credentialsProviderMechanismEnvVar)
+	err = setupCredentialsUsingCredentialsProvider(ctx, esConfig, key, mechanism, forceRefresh)
 	if err != nil {
 		return nil, err
 	}
 	return esConfig, nil
 }
 
-// setupCredentailsUsingCredentialsProvider sets up the credentials in the elasticsearch config.
+// setupCredentialsUsingCredentialsProvider sets up the credentials in the elasticsearch config.
 // It returns the updated config.
-func setupCredentailsUsingCredentialsProvider(ctx context.Context, esConfig *elasticsearch.Config, key string, mechanism string, forceRefresh bool) error {
+func setupCredentialsUsingCredentialsProvider(ctx context.Context, esConfig *elasticsearch.Config, key string, mechanism string, forceRefresh bool) error {
 	if key == "" {
 		return errCredentialProviderKeyNotSet
 	}

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -18,15 +18,20 @@ const DEFAULT_RESULT_SIZE_KEY = "esDefaultResultSize"
 var (
 	credentialsProviderKeyEnvVar       = "ELASTICSEARCH_CREDENTIALS_PROVIDER_KEY"
 	credentialsProviderMechanismEnvVar = "ELASTICSEARCH_CREDENTIALS_PROVIDER_MECHANISM"
-	credentialsProviderUri             = "HASURA_CREDENTIALS_PROVIDER_URI"
-	elasticsearchUrl                   = "ELASTICSEARCH_URL"
+	credentialsProviderUriEnvVar       = "HASURA_CREDENTIALS_PROVIDER_URI"
+	elasticsearchUrlEnvVar             = "ELASTICSEARCH_URL"
+
+	// Credentials provider mechanisms
+	apiKeyCredentialsProviderMechanism       = "api-key"
+	serviceTokenCredentialsProviderMechanism = "service-token"
+	bearerTokenCredentialsProviderMechanism  = "bearer-token"
 )
 
 var (
 	errCredentialProviderKeyNotSet        = fmt.Errorf("%s is not set", credentialsProviderKeyEnvVar)
 	errCredentialProviderMechanismNotSet  = fmt.Errorf("%s is not set", credentialsProviderMechanismEnvVar)
-	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"api-key\" or \"service-token\" or \"bearer-token\"", credentialsProviderMechanismEnvVar)
-	errElasticsearchUrlNotSet             = fmt.Errorf("%s is not set", elasticsearchUrl)
+	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"%s\" or \"%s\" or \"%s\"", credentialsProviderMechanismEnvVar, apiKeyCredentialsProviderMechanism, serviceTokenCredentialsProviderMechanism, bearerTokenCredentialsProviderMechanism)
+	errElasticsearchUrlNotSet             = fmt.Errorf("%s is not set", elasticsearchUrlEnvVar)
 )
 
 // getConfigFromEnv retrieves elastic search configuration from environment variables.
@@ -63,7 +68,7 @@ func getConfigFromEnv() (*elasticsearch.Config, error) {
 }
 
 func shouldUseCredentialsProvider() bool {
-	return os.Getenv(credentialsProviderUri) != ""
+	return os.Getenv(credentialsProviderUriEnvVar) != ""
 }
 
 func getConfigFromCredentialsProvider(ctx context.Context, forceRefresh bool) (*elasticsearch.Config, error) {
@@ -90,7 +95,7 @@ func setupCredentialsUsingCredentialsProvider(ctx context.Context, esConfig *ela
 	if mechanism == "" {
 		return errCredentialProviderMechanismNotSet
 	}
-	if mechanism != "api-key" && mechanism != "service-token" && mechanism != "bearer-token" {
+	if mechanism != apiKeyCredentialsProviderMechanism && mechanism != serviceTokenCredentialsProviderMechanism && mechanism != bearerTokenCredentialsProviderMechanism {
 		return errCredentialProviderMechanismInvalid
 	}
 
@@ -99,9 +104,9 @@ func setupCredentialsUsingCredentialsProvider(ctx context.Context, esConfig *ela
 		return err
 	}
 
-	if mechanism == "api-key" {
+	if mechanism == apiKeyCredentialsProviderMechanism {
 		esConfig.APIKey = credential
-	} else if mechanism == "service-token" {
+	} else if mechanism == serviceTokenCredentialsProviderMechanism {
 		esConfig.ServiceToken = credential
 	} else {
 		esConfig.Header.Add("Authorization", fmt.Sprintf("Bearer %s", credential))
@@ -130,7 +135,7 @@ func getBaseConfig() (*elasticsearch.Config, error) {
 	esConfig := elasticsearch.Config{}
 
 	// Read the address
-	address := os.Getenv(elasticsearchUrl)
+	address := os.Getenv(elasticsearchUrlEnvVar)
 	if address == "" {
 		return nil, errElasticsearchUrlNotSet
 	}

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -25,7 +25,7 @@ var (
 var (
 	errCredentialProviderKeyNotSet        = fmt.Errorf("%s is not set", credentailsProviderKeyEnvVar)
 	errCredentialProviderMechanismNotSet  = fmt.Errorf("%s is not set", credentailsProviderMechanismEnvVar)
-	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"api-key\" or \"service-token\"", credentailsProviderMechanismEnvVar)
+	errCredentialProviderMechanismInvalid = fmt.Errorf("invalid value for %s, should be either \"api-key\" or \"service-token\" or \"bearer-token\"", credentailsProviderMechanismEnvVar)
 	errElasticsearchUrlNotSet             = fmt.Errorf("%s is not set", elasticsearchUrl)
 )
 
@@ -90,7 +90,7 @@ func setupCredentailsUsingCredentialsProvider(ctx context.Context, esConfig *ela
 	if mechanism == "" {
 		return errCredentialProviderMechanismNotSet
 	}
-	if mechanism != "api-key" && mechanism != "service-token" {
+	if mechanism != "api-key" && mechanism != "service-token" && mechanism != "bearer-token" {
 		return errCredentialProviderMechanismInvalid
 	}
 
@@ -101,8 +101,10 @@ func setupCredentailsUsingCredentialsProvider(ctx context.Context, esConfig *ela
 
 	if mechanism == "api-key" {
 		esConfig.APIKey = credential
-	} else {
+	} else if mechanism == "service-token" {
 		esConfig.ServiceToken = credential
+	} else {
+		esConfig.Header.Add("Authorization", fmt.Sprintf("Bearer %s", credential))
 	}
 	return nil
 }

--- a/elasticsearch/config_test.go
+++ b/elasticsearch/config_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/elastic/go-elasticsearch/v8"
 )
 
-func TestSetupCredentailsUsingCredentialsProvider(t *testing.T) {
+func TestSetupCredentialsUsingCredentialsProvider(t *testing.T) {
 	t.Run("should return error if key is not set", func(t *testing.T) {
 		esConfig := elasticsearch.Config{}
-		err := setupCredentailsUsingCredentialsProvider(context.Background(), &esConfig, "", "", false)
+		err := setupCredentialsUsingCredentialsProvider(context.Background(), &esConfig, "", "", false)
 		if !errors.Is(err, errCredentialProviderKeyNotSet) {
 			t.Errorf("expected error to be errCredentialProviderKeyNotSet, got %v", err)
 		}
@@ -20,7 +20,7 @@ func TestSetupCredentailsUsingCredentialsProvider(t *testing.T) {
 	t.Run("key is set", func(t *testing.T) {
 		t.Run("should return error if mechanism is not set", func(t *testing.T) {
 			esConfig := elasticsearch.Config{}
-			err := setupCredentailsUsingCredentialsProvider(context.Background(), &esConfig, "key", "", false)
+			err := setupCredentialsUsingCredentialsProvider(context.Background(), &esConfig, "key", "", false)
 			if !errors.Is(err, errCredentialProviderMechanismNotSet) {
 				t.Errorf("expected error to be errCredentialProviderMechanismNotSet, got %v", err)
 			}
@@ -28,7 +28,7 @@ func TestSetupCredentailsUsingCredentialsProvider(t *testing.T) {
 
 		t.Run("should return error if mechanism is invalid", func(t *testing.T) {
 			esConfig := elasticsearch.Config{}
-			err := setupCredentailsUsingCredentialsProvider(context.Background(), &esConfig, "key", "invalid", false)
+			err := setupCredentialsUsingCredentialsProvider(context.Background(), &esConfig, "key", "invalid", false)
 			if !errors.Is(err, errCredentialProviderMechanismInvalid) {
 				t.Errorf("expected error to be errCredentialProviderMechanismInvalid, got %v", err)
 			}


### PR DESCRIPTION
Currently the NDC Elasticsearch connector credentials provider support authorization via `api-key` and `service-token`. This PR adds support for bearer tokens (like `oauth`) to the credentials provider