### PR TITLE
fix: Combine AND/OR conditions on same nested path into single nested query

### DIFF
--- a/connector/filter.go
+++ b/connector/filter.go
@@ -59,7 +59,9 @@ func buildAndClauseQuery(expressions []schema.Expression, state *types.State, co
 		}
 		queries = append(queries, res)
 	}
-	
+
+	queries = groupNestedQueriesByPath(queries, "must")
+
 	filter := make(map[string]interface{})
 	filter["bool"] = map[string]interface{}{
 		"must": queries,
@@ -92,7 +94,9 @@ func buildOrClauseQuery(expressions []schema.Expression, state *types.State, col
 		}
 		queries = append(queries, res)
 	}
-	
+
+	queries = groupNestedQueriesByPath(queries, "should")
+
 	filter := make(map[string]interface{})
 	filter["bool"] = map[string]interface{}{
 		"should": queries,
@@ -236,6 +240,73 @@ func joinFieldPath(state *types.State, fieldPath []string, columnName string, co
 	}
 
 	return joinedPath, nestedPath
+}
+
+// groupNestedQueriesByPath groups Elasticsearch nested queries that share the same top-level
+// nested path into a single nested query. Multiple conditions targeting the same nested path
+// are merged into one nested query with a bool clause containing all inner conditions,
+// ensuring they are evaluated against the same nested document rather than independently.
+func groupNestedQueriesByPath(queries []map[string]interface{}, boolClause string) []map[string]interface{} {
+	type slot struct {
+		isNested     bool
+		path         string
+		innerQueries []map[string]interface{}
+		rawQuery     map[string]interface{}
+	}
+
+	slots := make([]*slot, 0, len(queries))
+	pathToSlot := make(map[string]*slot)
+
+	for _, q := range queries {
+		nested, hasNested := q["nested"].(map[string]interface{})
+		if hasNested {
+			path, hasPath := nested["path"].(string)
+			innerQuery, hasInner := nested["query"].(map[string]interface{})
+			if hasPath && hasInner {
+				if s, seen := pathToSlot[path]; seen {
+					s.innerQueries = append(s.innerQueries, innerQuery)
+					continue
+				}
+				s := &slot{
+					isNested:     true,
+					path:         path,
+					innerQueries: []map[string]interface{}{innerQuery},
+				}
+				pathToSlot[path] = s
+				slots = append(slots, s)
+				continue
+			}
+		}
+		slots = append(slots, &slot{rawQuery: q})
+	}
+
+	result := make([]map[string]interface{}, 0, len(slots))
+	for _, s := range slots {
+		if !s.isNested {
+			result = append(result, s.rawQuery)
+			continue
+		}
+		if len(s.innerQueries) == 1 {
+			result = append(result, map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path":  s.path,
+					"query": s.innerQueries[0],
+				},
+			})
+		} else {
+			result = append(result, map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path": s.path,
+					"query": map[string]interface{}{
+						"bool": map[string]interface{}{
+							boolClause: s.innerQueries,
+						},
+					},
+				},
+			})
+		}
+	}
+	return result
 }
 
 func prepareNestedQuery(

--- a/testdata/unit_tests/query_tests/flights_nested/nested_filtering_and/want.json
+++ b/testdata/unit_tests/query_tests/flights_nested/nested_filtering_and/want.json
@@ -15,30 +15,31 @@
           "nested": {
             "path": "route.arrival_airport",
             "query": {
-              "nested": {
-                "path": "route.arrival_airport.location",
-                "query": {
-                  "nested": {
-                    "path": "route.arrival_airport.location.coordinates",
-                    "query": {
-                      "range": {
-                        "route.arrival_airport.location.coordinates.elevation": {
-                          "gte": "200"
+              "bool": {
+                "must": [
+                  {
+                    "nested": {
+                      "path": "route.arrival_airport.location",
+                      "query": {
+                        "nested": {
+                          "path": "route.arrival_airport.location.coordinates",
+                          "query": {
+                            "range": {
+                              "route.arrival_airport.location.coordinates.elevation": {
+                                "gte": "200"
+                              }
+                            }
+                          }
                         }
                       }
                     }
+                  },
+                  {
+                    "match": {
+                      "route.arrival_airport.terminals": "2"
+                    }
                   }
-                }
-              }
-            }
-          }
-        },
-        {
-          "nested": {
-            "path": "route.arrival_airport",
-            "query": {
-              "match": {
-                "route.arrival_airport.terminals": "2"
+                ]
               }
             }
           }

--- a/testdata/unit_tests/query_tests/flights_nested/nested_filtering_or/want.json
+++ b/testdata/unit_tests/query_tests/flights_nested/nested_filtering_or/want.json
@@ -17,18 +17,19 @@
           "nested": {
             "path": "route.arrival_airport",
             "query": {
-              "match": {
-                "route.arrival_airport.terminals": "4"
-              }
-            }
-          }
-        },
-        {
-          "nested": {
-            "path": "route.arrival_airport",
-            "query": {
-              "match": {
-                "route.arrival_airport.terminals": "2"
+              "bool": {
+                "should": [
+                  {
+                    "match": {
+                      "route.arrival_airport.terminals": "4"
+                    }
+                  },
+                  {
+                    "match": {
+                      "route.arrival_airport.terminals": "2"
+                    }
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
## Summary

- **Bug**: When a GraphQL filter uses `_and` (or `_or`) with multiple conditions on the same nested field, the connector generated a **separate** Elasticsearch `nested` query per condition. Elasticsearch evaluates these independently — different nested documents can satisfy different conditions. This is semantically wrong for `_and`, where all conditions must apply to the **same** nested document.
- **Fix**: Added `groupNestedQueriesByPath` in `connector/filter.go`, called from both `buildAndClauseQuery` and `buildOrClauseQuery`. After processing each expression into its own ES query, it groups `nested` queries sharing the same `path` and merges them into a single `nested` query whose inner query is a `bool.must` (for `_and`) or `bool.should` (for `_or`).
- **Tests**: Updated `want.json` fixtures for `flights_nested/nested_filtering_and` and `flights_nested/nested_filtering_or`. All 43 existing query tests pass.

## Before / After

**Before** — three separate nested queries, each evaluated independently:

```json
{ "bool": { "must": [
  { "nested": { "path": "INFIELD_GRADES_ARRAY", "query": { "match": { "INFIELD_GRADES_ARRAY.PLAYER_ID": 77131 } } } },
  { "nested": { "path": "INFIELD_GRADES_ARRAY", "query": { "range": { "INFIELD_GRADES_ARRAY.CONTRIB_PROB_FIELDED": { "gt": 0.2 } } } } },
  { "nested": { "path": "INFIELD_GRADES_ARRAY", "query": { "range": { "INFIELD_GRADES_ARRAY.RV_ADDED": { "gt": 0.01 } } } } }
] } }
```

**After** — single nested query, all conditions applied to the same document:

```json
{ "bool": { "must": [
  { "nested": { "path": "INFIELD_GRADES_ARRAY", "query": { "bool": { "must": [
    { "match": { "INFIELD_GRADES_ARRAY.PLAYER_ID": 77131 } },
    { "range": { "INFIELD_GRADES_ARRAY.CONTRIB_PROB_FIELDED": { "gt": 0.2 } } },
    { "range": { "INFIELD_GRADES_ARRAY.RV_ADDED": { "gt": 0.01 } } }
  ] } } } }
] } }
```

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `flights_nested.nested_filtering_and` — updated fixture, passes with grouped output
- [x] `flights_nested.nested_filtering_or` — updated fixture, passes with grouped output
- [x] All other 41 tests unaffected

Co-authored-by: Parikshith Mechineni <parikshith.mechineni@hasura.io>