### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.26 AS builder
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -10,7 +10,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o ndc-elasticsearch
 
 # Stage 2: Create a minimal image with the Go binary
-FROM alpine:3
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3-stable
 
 # Install necessary certificates for the application to run
 RUN apk update && \


### PR DESCRIPTION
## What

Re-homes the base images in `Dockerfile` to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images` via floating `-stable` aliases. These aliases auto-advance to the latest patched digest of the same version line, so patches are picked up automatically without bumping versions.

Per Hasura policy, every container deployed in Hasura infra must be pulled from the private Artifact Registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.). Upstream images are vendored there using a `preserve-source` path layout.

## Exact FROM swaps

`Dockerfile`:
- `FROM golang:1.26` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable`
- `FROM alpine:3` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3-stable`

(The `AS builder` stage suffix on the golang line is preserved unchanged.)

## Notes

- Part of an org-wide **Phase 1** migration — exact-match swaps only. No version bumps, no reformatting, no other lines touched.
- Same version lines (`1.26`, `3`); only the registry/tag-alias is changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
