### PR TITLE
fix(elasticsearch): replay query body on 401 re-auth retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix `_search` payload being dropped on the 401 re-authentication retry. The retry reused an already-drained request body and sent an empty `_search` body, which Elasticsearch interprets as `match_all`, returning wrong/unfiltered results after a credential refresh. The retry now replays the original query body, and a transport-level error from the first request is checked before the response is used.
+- Log the actual `_search` request (target index and body) sent on each attempt at `DEBUG` level. The post-401 retry is logged with a `"Retry Query"` marker so retry requests can be distinguished from first-attempt `"Query"` requests. Credentials/auth headers are not logged.
 
 ## [1.10.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix `_search` payload being dropped on the 401 re-authentication retry. The retry reused an already-drained request body and sent an empty `_search` body, which Elasticsearch interprets as `match_all`, returning wrong/unfiltered results after a credential refresh. The retry now replays the original query body, and a transport-level error from the first request is checked before the response is used.
+
 ## [1.10.2]
 
 - Fix reported vulnerabilities.

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
@@ -179,6 +180,8 @@ func (e *Client) Search(ctx context.Context, index string, body map[string]inter
 
 // search is a helper function to perform a search operation in elastic search.
 func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*esapi.Response, error) {
+	logger := connector.GetLogger(ctx)
+
 	req := &esapi.SearchRequest{}
 
 	for _, opt := range o {
@@ -206,7 +209,14 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 		}
 	}
 
+	// index and body are logged on each attempt so the exact _search request that
+	// goes over the wire is observable. Because seedBody re-seeds req.Body with
+	// exactly these bytes before every attempt, string(body) reflects what is
+	// actually sent (auth headers/credentials are never logged).
+	index := strings.Join(req.Index, ",")
+
 	seedBody()
+	logger.DebugContext(ctx, "Query", "index", index, "body", string(body))
 	res, err := req.Do(ctx, e.client)
 	// Check the transport error before touching res: on a transport-level failure
 	// req.Do returns (nil, err), so dereferencing res first would panic.
@@ -221,6 +231,9 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 				return nil, fmt.Errorf("error: %w", err)
 			}
 			seedBody()
+			// "Retry Query" marks the post-401 retry so it can be grepped apart
+			// from first-attempt "Query" log lines.
+			logger.DebugContext(ctx, "Retry Query", "index", index, "body", string(body))
 			res, err = req.Do(ctx, e.client)
 			if err != nil {
 				return nil, fmt.Errorf("error: %w", err)

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/elastic/go-elasticsearch/v8"
@@ -19,6 +20,18 @@ import (
 
 type Client struct {
 	client *elasticsearch.Client
+	// reauthenticate refreshes credentials when Elasticsearch returns a 401.
+	// It defaults to (*Client).Reauthenticate; tests may override it to avoid
+	// rebuilding the underlying client (and its transport) on retry.
+	reauthenticate func(ctx context.Context) error
+}
+
+// reauth refreshes credentials on a 401, using the overridable hook when set.
+func (e *Client) reauth(ctx context.Context) error {
+	if e.reauthenticate != nil {
+		return e.reauthenticate(ctx)
+	}
+	return e.Reauthenticate(ctx)
 }
 
 // NewClient creates a new client with configuration from cfg.
@@ -172,18 +185,45 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 		opt(req)
 	}
 
+	// req.Body is an io.Reader that esapi drains while building the HTTP request.
+	// Capture its bytes once so the request can be replayed: without this, the
+	// 401 retry below would reuse the already-drained reader and send an empty
+	// _search body, which Elasticsearch interprets as match_all (dropping the
+	// actual query and returning wrong results).
+	var body []byte
+	if req.Body != nil {
+		var err error
+		body, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading search request body: %w", err)
+		}
+	}
+	// seedBody resets req.Body to a fresh reader over the captured bytes so every
+	// attempt transmits the same payload.
+	seedBody := func() {
+		if body != nil {
+			req.Body = bytes.NewReader(body)
+		}
+	}
+
+	seedBody()
 	res, err := req.Do(ctx, e.client)
+	// Check the transport error before touching res: on a transport-level failure
+	// req.Do returns (nil, err), so dereferencing res first would panic.
+	if err != nil {
+		return nil, fmt.Errorf("error while querying: %w", err)
+	}
 
 	if res.IsError() {
 		if res.StatusCode == 401 {
-			// Unauthorized error, reauthenticate and retry
-			err = e.Reauthenticate(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("error: %s", err)
+			// Unauthorized error, reauthenticate and retry with the same body.
+			if err = e.reauth(ctx); err != nil {
+				return nil, fmt.Errorf("error: %w", err)
 			}
+			seedBody()
 			res, err = req.Do(ctx, e.client)
 			if err != nil {
-				return nil, fmt.Errorf("error: %s", err)
+				return nil, fmt.Errorf("error: %w", err)
 			}
 		} else {
 			return nil, fmt.Errorf("error while querying: %s", res.String())

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -1,0 +1,177 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// testModeEnvVar toggles which search implementation the functional test below
+// exercises, so the same assertion can be run against both the buggy and the
+// fixed code without editing any source:
+//
+//	ES_401_TEST_MODE=buggy go test -run TestSearch401RetrySendsSameBody ./elasticsearch/  -> FAILS (reproduces the bug)
+//	ES_401_TEST_MODE=fixed go test -run TestSearch401RetrySendsSameBody ./elasticsearch/  -> PASSES (verifies the fix)
+//
+// "fixed" is the default when the variable is unset.
+const testModeEnvVar = "ES_401_TEST_MODE"
+
+// recordingTransport is a fake http.RoundTripper standing in for Elasticsearch.
+// It returns 401 on the first attempt (to trigger the connector's re-auth +
+// retry path) and 200 on every subsequent attempt, while recording the exact
+// request body it received on each attempt. The recorded retry body is the
+// crux of the bug: a correct connector must replay the original query body.
+type recordingTransport struct {
+	bodies [][]byte
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body []byte
+	if req.Body != nil {
+		body, _ = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+	}
+	rt.bodies = append(rt.bodies, body)
+
+	header := http.Header{
+		"Content-Type": []string{"application/json"},
+		// Required so the go-elasticsearch product check passes on 2xx responses.
+		"X-Elastic-Product": []string{"Elasticsearch"},
+	}
+
+	// First attempt -> 401 Unauthorized, to drive the re-auth + retry branch.
+	if len(rt.bodies) == 1 {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"error":"unauthorized"}`)),
+			Request:    req,
+		}, nil
+	}
+
+	// Retry -> 200 OK with a minimal valid search response.
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(`{"took":1,"timed_out":false,"hits":{"total":{"value":0,"relation":"eq"},"hits":[]}}`)),
+		Request:    req,
+	}, nil
+}
+
+// buggySearch is a faithful copy of the pre-fix search() body handling
+// introduced in commit 3431d53 (PR #72, first shipped in v1.5.2). It reuses the
+// already-drained request body on the 401 retry, so the retried _search carries
+// an empty body. It exists only to let this test reproduce the original bug via
+// ES_401_TEST_MODE=buggy without checking out an old revision.
+func buggySearch(e *Client, ctx context.Context, o ...func(*esapi.SearchRequest)) (*esapi.Response, error) {
+	req := &esapi.SearchRequest{}
+	for _, opt := range o {
+		opt(req)
+	}
+
+	res, err := req.Do(ctx, e.client)
+	if res.IsError() {
+		if res.StatusCode == 401 {
+			if err = e.reauth(ctx); err != nil {
+				return nil, fmt.Errorf("error: %s", err)
+			}
+			res, err = req.Do(ctx, e.client) // reuses the drained body -> empty payload
+			if err != nil {
+				return nil, fmt.Errorf("error: %s", err)
+			}
+		} else {
+			return nil, fmt.Errorf("error while querying: %s", res.String())
+		}
+	}
+	return res, err
+}
+
+// TestSearch401RetrySendsSameBody is a functional test for the 401-retry
+// payload-drop bug. It drives a real *Client through a 401 -> re-auth -> retry
+// cycle against a fake Elasticsearch transport and asserts that the body sent on
+// the retry is byte-for-byte identical to the body sent on the first attempt.
+//
+// Run it both ways (the assertion is identical; only the implementation differs):
+//
+//	ES_401_TEST_MODE=buggy go test -v -run TestSearch401RetrySendsSameBody ./elasticsearch/   # reproduces the bug -> FAIL
+//	ES_401_TEST_MODE=fixed go test -v -run TestSearch401RetrySendsSameBody ./elasticsearch/   # verifies the fix   -> PASS
+func TestSearch401RetrySendsSameBody(t *testing.T) {
+	mode := os.Getenv(testModeEnvVar)
+	if mode == "" {
+		mode = "fixed"
+	}
+
+	ctx := context.Background()
+	queryBody := []byte(`{"query":{"term":{"title":"hasura"}}}`)
+
+	transport := &recordingTransport{}
+	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses:    []string{"http://elasticsearch.invalid:9200"},
+		Transport:    transport,
+		DisableRetry: true, // keep attempt counting deterministic; 401 isn't retried by the transport anyway
+	})
+	if err != nil {
+		t.Fatalf("failed to build elasticsearch client: %v", err)
+	}
+
+	e := &Client{
+		client: esClient,
+		// Keep the fake transport in place on re-auth (the real Reauthenticate
+		// would rebuild the client and drop our transport).
+		reauthenticate: func(context.Context) error { return nil },
+	}
+
+	opts := []func(*esapi.SearchRequest){
+		func(r *esapi.SearchRequest) { r.Index = []string{"test-index"} },
+		// Mirror production: the body is a *bytes.Buffer, exactly as Search() builds it.
+		func(r *esapi.SearchRequest) { r.Body = bytes.NewBuffer(queryBody) },
+	}
+
+	t.Logf("running in %q mode (set %s=buggy or =fixed to toggle)", mode, testModeEnvVar)
+	switch mode {
+	case "buggy":
+		_, err = buggySearch(e, ctx, opts...)
+	case "fixed":
+		_, err = e.search(ctx, opts...)
+	default:
+		t.Fatalf("unknown %s=%q (want \"buggy\" or \"fixed\")", testModeEnvVar, mode)
+	}
+	if err != nil {
+		t.Fatalf("search returned an unexpected error: %v", err)
+	}
+
+	if len(transport.bodies) != 2 {
+		t.Fatalf("expected exactly 2 requests to ES (initial + retry), got %d", len(transport.bodies))
+	}
+
+	firstBody := transport.bodies[0]
+	retryBody := transport.bodies[1]
+	t.Logf("first-attempt body: %s", firstBody)
+	t.Logf("retry body:         %q (len=%d)", retryBody, len(retryBody))
+
+	// Sanity: the first attempt must have carried the real query.
+	if strings.TrimSpace(string(firstBody)) != string(queryBody) {
+		t.Fatalf("first attempt sent an unexpected body: got %q, want %q", firstBody, queryBody)
+	}
+
+	// The crux: the 401 retry must transmit the SAME query body. The buggy
+	// implementation sends an empty body here (Elasticsearch would treat it as
+	// match_all), so this assertion fails in ES_401_TEST_MODE=buggy and passes
+	// once the fix re-seeds the request body before retrying.
+	if strings.TrimSpace(string(retryBody)) != string(queryBody) {
+		t.Errorf("401 retry sent the wrong body (payload dropped):\n  got:  %q (len=%d)\n  want: %q\n"+
+			"An empty/short body means the retry was sent without the query, which Elasticsearch "+
+			"interprets as match_all. This is the bug from commit 3431d53 / PR #72.",
+			retryBody, len(retryBody), queryBody)
+	}
+}

--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -173,5 +174,79 @@ func TestSearch401RetrySendsSameBody(t *testing.T) {
 			"An empty/short body means the retry was sent without the query, which Elasticsearch "+
 			"interprets as match_all. This is the bug from commit 3431d53 / PR #72.",
 			retryBody, len(retryBody), queryBody)
+	}
+}
+
+// TestSearch401RetryLogsBodyPerAttempt verifies the per-attempt request logging
+// requested in support ticket #15000: the connector must log the actual _search
+// request (target index + body) it sends on EACH attempt, and the post-401
+// retry log line must carry the literal marker "Retry Query" so it can be
+// grepped apart from first-attempt "Query" lines.
+//
+// It captures the connector's structured logs (slog) and asserts both markers
+// are emitted with the real query body. Because the fix re-seeds the request
+// body before every attempt, the logged body matches what is actually sent over
+// the wire on both the first attempt and the retry.
+func TestSearch401RetryLogsBodyPerAttempt(t *testing.T) {
+	// Route connector.GetLogger's fallback (no logger in ctx) at debug level into
+	// a buffer we can assert on. slog.Default is global, so restore it after.
+	var logBuf bytes.Buffer
+	prevDefault := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prevDefault)
+
+	ctx := context.Background()
+	queryBody := []byte(`{"query":{"term":{"title":"hasura"}}}`)
+
+	transport := &recordingTransport{}
+	esClient, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses:    []string{"http://elasticsearch.invalid:9200"},
+		Transport:    transport,
+		DisableRetry: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to build elasticsearch client: %v", err)
+	}
+
+	e := &Client{
+		client:         esClient,
+		reauthenticate: func(context.Context) error { return nil },
+	}
+
+	opts := []func(*esapi.SearchRequest){
+		func(r *esapi.SearchRequest) { r.Index = []string{"test-index"} },
+		func(r *esapi.SearchRequest) { r.Body = bytes.NewBuffer(queryBody) },
+	}
+
+	if _, err = e.search(ctx, opts...); err != nil {
+		t.Fatalf("search returned an unexpected error: %v", err)
+	}
+
+	logs := logBuf.String()
+	t.Logf("captured logs:\n%s", logs)
+
+	// First-attempt log line.
+	if !strings.Contains(logs, `"msg":"Query"`) {
+		t.Errorf("expected a first-attempt %q log line; got:\n%s", "Query", logs)
+	}
+	// Retry log line carrying the required marker.
+	if !strings.Contains(logs, `"msg":"Retry Query"`) {
+		t.Errorf("expected a %q marked log line on the 401 retry; got:\n%s", "Retry Query", logs)
+	}
+	// Both log lines must include the actual query body and target index. The
+	// body is JSON-escaped inside the JSON log record, so assert on a stable
+	// fragment of the query.
+	if strings.Count(logs, `term`) < 2 || strings.Count(logs, `title`) < 2 {
+		t.Errorf("expected the real query body to be logged on both attempts; got:\n%s", logs)
+	}
+	if strings.Count(logs, `"index":"test-index"`) < 2 {
+		t.Errorf("expected the target index to be logged on both attempts; got:\n%s", logs)
+	}
+	// Sanity: the fake never sends credentials, but guard against accidentally
+	// logging common auth fields from this path.
+	for _, secret := range []string{"Authorization", "password", "apiKey", "api_key", "ServiceToken"} {
+		if strings.Contains(logs, secret) {
+			t.Errorf("log output unexpectedly contains a credential-like field %q:\n%s", secret, logs)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a payload-drop bug in the Elasticsearch `_search` path and adds per-attempt request logging.

After Elasticsearch returns a **401** and the connector re-authenticates and retries, the retry was sent with an **empty request body**. Elasticsearch interprets an empty `_search` body as `match_all`, so once credentials expire/rotate mid-traffic, queries silently return **wrong/unfiltered results**.

## Root cause

In `elasticsearch/client.go`, `search()` builds an `esapi.SearchRequest` whose `Body` is a `*bytes.Buffer`. `req.Do` drains that buffer while building the HTTP request. On a 401 the code re-authenticated and called `req.Do` **again on the same `req`**, whose body was already drained — so the retried `_search` carried `Content-Length: 0` / an empty body → `match_all`.

A secondary issue: the first `req.Do` error was not checked before `res.IsError()` was called, so a transport-level failure (which returns `nil, err`) could cause a nil-pointer panic.

**Provenance:** introduced in commit `3431d53` (PR #72, "re-authenticate when elasticsearch returns a 401 error"), first shipped in **v1.5.2**, and unchanged through the latest release **v1.10.2**. The bug is intermittent because it only triggers after a 401 (credential/token expiry or rotation).

## Fix

- Capture the request body bytes once, then re-seed `req.Body` with a fresh `bytes.NewReader` before **each** attempt, so the retry transmits the identical query payload.
- Check the error returned by the first `req.Do` **before** touching the response, removing the nil-deref panic risk.
- The same `search()` helper backs both `Search` and `ExplainSearch`, so both paths are fixed.

## Per-attempt request logging (support ticket #15000, JPMorgan Chase)

The connector now logs the **actual `_search` request it sends on each attempt** — the target index and the request body that goes over the wire — using the connector's existing structured logger (`connector.GetLogger`, `slog`) at **`DEBUG`** level:

- First attempt logs `msg="Query"`.
- The post-401 retry logs `msg="Retry Query"` — a literal marker so retry requests are easy to grep/distinguish from first-attempt queries.

Because the fix re-seeds the request body before each attempt, the logged body reflects exactly what is sent on **both** the first attempt and the retry. This is also what makes the bug observable: before the fix the retry shipped an empty body; after the fix it ships the correct body. Credentials/auth headers are **not** logged.

Example (debug level) — first attempt then retry:

```json
{"level":"DEBUG","msg":"Query","index":"my-index","body":"{\"query\":{\"term\":{\"title\":\"hasura\"}}}"}
{"level":"DEBUG","msg":"Retry Query","index":"my-index","body":"{\"query\":{\"term\":{\"title\":\"hasura\"}}}"}
```

Grep the retry log lines with:

```bash
# structured logs
grep '"msg":"Retry Query"' <connector-logs>
# or just the marker
grep 'Retry Query' <connector-logs>
```

## Functional tests — reproduce the bug, verify the fix, and verify the logging

Added in `elasticsearch/client_test.go`:

### 1. `TestSearch401RetrySendsSameBody` — body on the wire
Drives a real `*Client` through a **401 → re-auth → retry** cycle against a fake Elasticsearch transport (`recordingTransport`) that returns 401 then 200, **recording the exact body sent on each attempt**, and asserts the retry body equals the first-attempt body.

The same assertion runs against both implementations via `ES_401_TEST_MODE` (no source edits needed to flip between them):

```bash
# OLD / buggy behaviour — reproduces the empty-body-on-retry -> test FAILS
ES_401_TEST_MODE=buggy go test -v -run TestSearch401RetrySendsSameBody ./elasticsearch/

# NEW / fixed behaviour (default) — retry replays the query body -> test PASSES
ES_401_TEST_MODE=fixed go test -v -run TestSearch401RetrySendsSameBody ./elasticsearch/
```

In `buggy` mode the recorded retry body is empty (`len=0`), so the assertion fails — reproducing the production symptom. In `fixed` mode (default, also what CI runs) it passes.

### 2. `TestSearch401RetryLogsBodyPerAttempt` — the logging
Captures the connector's structured logs and asserts both the `"Query"` and `"Retry Query"` markers are emitted, each carrying the real query body and target index, and that no credential-like fields are logged.

```bash
go test -v -run TestSearch401RetryLogsBodyPerAttempt ./elasticsearch/
```

Full suite (race-enabled, as CI runs it):

```bash
make unit-test
```

## Traceability

Originating PromptQL thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/ff214ba1-1075-444d-a3ba-56f11ed6c3d8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
