### PR TITLE
fix(client): replace query body logging with body_bytes to avoid PII exposure

### DIFF
--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -190,7 +190,7 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 
 	// First attempt.
 	req.Body = bytes.NewReader(body)
-	logger.DebugContext(ctx, "Query", "index", index, "body", string(body))
+	logger.DebugContext(ctx, "Query", "index", index, "body_bytes", len(body))
 	res, err := req.Do(ctx, e.client)
 	// Check the transport error before touching res: on a transport-level
 	// failure res is nil and res.IsError() would panic.
@@ -209,7 +209,7 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 			// holds exactly these bytes, so logging string(body) reflects what is
 			// actually sent over the wire.
 			req.Body = bytes.NewReader(body)
-			logger.DebugContext(ctx, "Retry Query", "index", index, "body", string(body))
+			logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", len(body))
 			res, err = req.Do(ctx, e.client)
 			if err != nil {
 				return nil, fmt.Errorf("error: %s", err)

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -190,7 +190,7 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 
 	// First attempt.
 	req.Body = bytes.NewReader(body)
-	logger.DebugContext(ctx, "Query", "index", index, "body_bytes", len(body))
+	logger.DebugContext(ctx, "Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
 	res, err := req.Do(ctx, e.client)
 	// Check the transport error before touching res: on a transport-level
 	// failure res is nil and res.IsError() would panic.
@@ -209,7 +209,7 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 			// holds exactly these bytes, so logging string(body) reflects what is
 			// actually sent over the wire.
 			req.Body = bytes.NewReader(body)
-			logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", len(body))
+			logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
 			res, err = req.Do(ctx, e.client)
 			if err != nil {
 				return nil, fmt.Errorf("error: %s", err)

--- a/elasticsearch/client_retry_test.go
+++ b/elasticsearch/client_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -178,16 +179,16 @@ func TestSearchPerAttemptLogging(t *testing.T) {
 		t.Errorf(`expected the target index in the log line, not found in:\n%s`, logs)
 	}
 
-	// The logged retry body must reflect what is ACTUALLY sent on the wire: a
-	// non-empty body identical to the first attempt.
-	retryBody := logFieldForMsg(t, logs, "Retry Query", "body")
-	if trimWS(retryBody) == "" {
-		t.Fatalf("expected a non-empty logged retry body, got %q", retryBody)
+	// body_bytes must be non-zero on both attempts, proving the retry carries a
+	// real payload (body_bytes=0 would mean the bug is present).
+	if logFieldForMsg(t, logs, "Query", "body_bytes") == "0" || logFieldForMsg(t, logs, "Query", "body_bytes") == "" {
+		t.Errorf("expected non-zero body_bytes on first attempt")
 	}
-	if !jsonEqual(t, retryBody, logFieldForMsg(t, logs, "Query", "body")) {
-		t.Errorf("logged retry body %q does not match first attempt body", retryBody)
+	retryBodyBytes := logFieldForMsg(t, logs, "Retry Query", "body_bytes")
+	if retryBodyBytes == "0" || retryBodyBytes == "" {
+		t.Fatalf("expected non-zero body_bytes on retry attempt, got %q", retryBodyBytes)
 	}
-	t.Logf("retry logged the full body: %s", retryBody)
+	t.Logf("retry logged body_bytes=%s", retryBodyBytes)
 }
 
 // logFieldForMsg returns the value of field for the first JSON log record whose
@@ -203,8 +204,11 @@ func logFieldForMsg(t *testing.T, logs, msg, field string) string {
 			continue
 		}
 		if rec["msg"] == msg {
-			if v, ok := rec[field].(string); ok {
+			switch v := rec[field].(type) {
+			case string:
 				return v
+			case float64:
+				return fmt.Sprintf("%g", v)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Replaces the `body` log field (raw query JSON) with `body_bytes` (payload size in bytes) in the per-attempt debug logs added in #118.
- The raw query body can contain PII in filter values (e.g. customer IDs, account numbers in `term` queries). Logging the size is sufficient to diagnose the dropped-payload bug — `body_bytes=0` on a retry would indicate the bug is present.
- Updates `TestSearchPerAttemptLogging` to assert `body_bytes` is non-zero on both attempts instead of comparing body content.

## Test plan

- [ ] `go test -v -run TestSearchRetryBodyOn401 ./elasticsearch/` — passes
- [ ] `go test -v -run TestSearchPerAttemptLogging ./elasticsearch/` — passes
- [ ] `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)