### PR TITLE
fix(client): actionable, PII-safe errors + log/error PII sweep

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -52,7 +52,7 @@ func (c *Connector) TryInitState(ctx context.Context, configuration *types.Confi
 
 // HealthCheck checks the health of the connector.
 func (c *Connector) HealthCheck(ctx context.Context, configuration *types.Configuration, state *types.State) error {
-	if err := state.Client.Ping(); err != nil {
+	if err := state.Client.Ping(ctx); err != nil {
 		return err
 	}
 	return nil

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -28,7 +28,7 @@ func NewClient(ctx context.Context) (*Client, error) {
 	client := &Client{}
 	err := client.Authenticate(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error authenticating with elasticsearch: %s", err)
+		return nil, fmt.Errorf("could not authenticate with elasticsearch: %w", err)
 	}
 	return client, nil
 }
@@ -45,23 +45,23 @@ func (e *Client) Authenticate(ctx context.Context) error {
 	// actual errors are recorded in the span
 	esConfig, err := e.accquireAuthConfig(ctx, false)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to get AuthConfig")
+		logger.ErrorContext(ctx, "failed to get AuthConfig", "category", "es_auth_or_connectivity")
 		logger.DebugContext(ctx, "failed to get AuthConfig", "error", err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(fmt.Errorf("failed to get AuthConfig: %w", err))
-		return errors.New("internal error")
+		return errors.New("elasticsearch authentication configuration is invalid or missing: set ELASTICSEARCH_URL and credentials (ELASTICSEARCH_USERNAME/PASSWORD or ELASTICSEARCH_API_KEY)")
 	}
 	esClient, err := elasticsearch.NewClient(*esConfig)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create elasticsearch client")
+		logger.ErrorContext(ctx, "failed to create elasticsearch client", "category", "es_auth_or_connectivity")
 		logger.DebugContext(ctx, "failed to create elasticsearch client", "error", err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
-		return errors.New("internal error")
+		return errors.New("failed to initialize elasticsearch client from the provided configuration; check ELASTICSEARCH_URL/credentials/CA cert")
 	}
 	e.client = esClient
 	// Ping the client to check if the connection is successful
-	err = e.Ping()
+	err = e.Ping(ctx)
 	if err == nil {
 		// authenticated successfully
 		return nil
@@ -73,29 +73,29 @@ func (e *Client) Authenticate(ctx context.Context) error {
 	// if the ping fails, try to authenticate again with force refreshing the credentials
 	esConfig, err = e.accquireAuthConfig(ctx, true)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to get AuthConfig")
+		logger.ErrorContext(ctx, "failed to get AuthConfig", "category", "es_auth_or_connectivity")
 		logger.DebugContext(ctx, "failed to get AuthConfig", "error", err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(fmt.Errorf("failed to get AuthConfig: %w", err))
-		return errors.New("internal error")
+		return errors.New("elasticsearch authentication configuration is invalid or missing: set ELASTICSEARCH_URL and credentials (ELASTICSEARCH_USERNAME/PASSWORD or ELASTICSEARCH_API_KEY)")
 	}
 	esClient, err = elasticsearch.NewClient(*esConfig)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to create elasticsearch client")
+		logger.ErrorContext(ctx, "failed to create elasticsearch client", "category", "es_auth_or_connectivity")
 		logger.DebugContext(ctx, "failed to create elasticsearch client", "error", err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
-		return errors.New("internal error")
+		return errors.New("failed to initialize elasticsearch client from the provided configuration; check ELASTICSEARCH_URL/credentials/CA cert")
 	}
 	e.client = esClient
 	// Ping the client to check if the connection is successful
-	err = e.Ping()
+	err = e.Ping(ctx)
 	if err != nil {
-		logger.ErrorContext(ctx, "failed to ping elasticsearch")
+		logger.ErrorContext(ctx, "failed to ping elasticsearch", "category", "es_auth_or_connectivity")
 		logger.DebugContext(ctx, "elasticsearch ping error", "error", err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(fmt.Errorf("failed to ping elasticsearch: %w", err))
-		return errors.New("internal error")
+		return errors.New("elasticsearch authentication failed: credentials were rejected or the cluster is unreachable after re-authentication (HTTP 401 / connection). Verify credentials and that they are not expired/rotated")
 	}
 
 	return nil
@@ -124,13 +124,16 @@ func (e *Client) accquireAuthConfig(ctx context.Context, forceRefresh bool) (*el
 }
 
 // Ping returns whether the Elasticsearch cluster is running.
-func (e *Client) Ping() error {
+func (e *Client) Ping(ctx context.Context) error {
+	logger := connector.GetLogger(ctx)
 	res, err := e.client.Ping()
 	if err != nil {
-		return fmt.Errorf("failed to ping elasticsearch: %w", err)
+		return fmt.Errorf("cannot connect to elasticsearch (network/TLS error); check ELASTICSEARCH_URL and connectivity: %w", err)
 	}
 	if res.IsError() {
-		return fmt.Errorf("failed to ping elasticsearch: %s", res.String())
+		// Keep the raw cluster response at DEBUG only; never surface it to consumers.
+		logger.DebugContext(ctx, "elasticsearch ping error response", "status", res.StatusCode, "body", res.String())
+		return fmt.Errorf("elasticsearch health check failed: cluster returned HTTP %d (%s); verify ELASTICSEARCH_URL and that the cluster is reachable", res.StatusCode, res.Status())
 	}
 
 	defer res.Body.Close()
@@ -142,7 +145,7 @@ func (e *Client) Ping() error {
 func (e *Client) Search(ctx context.Context, index string, body map[string]interface{}) (map[string]interface{}, error) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(body); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to encode the search query (internal): %w", err)
 	}
 
 	search := esapi.Search(func(o ...func(*esapi.SearchRequest)) (*esapi.Response, error) {
@@ -195,14 +198,14 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 	// Check the transport error before touching res: on a transport-level
 	// failure res is nil and res.IsError() would panic.
 	if err != nil {
-		return nil, fmt.Errorf("error while querying: %s", err)
+		return nil, fmt.Errorf("elasticsearch request failed before a response (network/TLS); check connectivity to the cluster: %w", err)
 	}
 
 	if res.IsError() {
 		if res.StatusCode == 401 {
 			// Unauthorized error, reauthenticate and retry.
 			if err = e.Reauthenticate(ctx); err != nil {
-				return nil, fmt.Errorf("error: %s", err)
+				return nil, fmt.Errorf("re-authentication after an HTTP 401 failed; credentials may be expired/rotated or invalid: %w", err)
 			}
 			// Rebuild the body so the retried request carries the same query
 			// instead of the already-drained (empty) reader. The retried reader
@@ -212,10 +215,12 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 			logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
 			res, err = req.Do(ctx, e.client)
 			if err != nil {
-				return nil, fmt.Errorf("error: %s", err)
+				return nil, fmt.Errorf("elasticsearch request failed on the post-401 retry (network/TLS): %w", err)
 			}
 		} else {
-			return nil, fmt.Errorf("error while querying: %s", res.String())
+			// Keep the raw cluster response body at DEBUG only; never surface it to consumers.
+			logger.DebugContext(ctx, "es search error response", "status", res.StatusCode, "index", index, "body", res.String())
+			return nil, fmt.Errorf("elasticsearch returned an error for the search (HTTP %d %s); see debug logs for details", res.StatusCode, res.Status())
 		}
 	}
 	return res, err
@@ -244,7 +249,7 @@ func (e *Client) ExplainSearch(ctx context.Context, index string, query map[stri
 
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(query); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to encode the search query (internal): %w", err)
 	}
 
 	// `profile=true` is added to the query in the Buffer
@@ -291,7 +296,7 @@ func (e *Client) GetIndices(ctx context.Context) ([]string, error) {
 	// Perform the request
 	res, err := req.Do(context.Background(), e.client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting indices: %s", err)
+		return nil, fmt.Errorf("failed to list elasticsearch indices (check connectivity/permissions): %w", err)
 	}
 
 	indices, err := parseResponse(ctx, res)
@@ -324,7 +329,7 @@ func (e *Client) GetAliases(ctx context.Context) (aliasToIndexMap map[string]str
 	// Perform the request
 	res, err := req.Do(context.Background(), e.client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting aliases: %s", err)
+		return nil, fmt.Errorf("failed to list elasticsearch aliases (check connectivity/permissions): %w", err)
 	}
 
 	result, err := parseResponse(ctx, res)
@@ -334,14 +339,14 @@ func (e *Client) GetAliases(ctx context.Context) (aliasToIndexMap map[string]str
 
 	resultJson, err := json.Marshal(result)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling alias result to JSON: %s", err)
+		return nil, fmt.Errorf("failed to process the elasticsearch alias response (internal): %w", err)
 	}
 
 	// Parse alias result to get alias to index mapping
 	unmarshalledJsonArray := make([]map[string]string, 0)
 	err = json.Unmarshal(resultJson, &unmarshalledJsonArray)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling alias result: %s", err)
+		return nil, fmt.Errorf("failed to process the elasticsearch alias response (internal): %w", err)
 	}
 
 	aliasToIndexMap = make(map[string]string)
@@ -376,7 +381,7 @@ func (e *Client) GetMappings(ctx context.Context, indices []string) (mappings ma
 	// Perform the request
 	res, err := req.Do(context.Background(), e.client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting mappings: %s", err)
+		return nil, fmt.Errorf("failed to get elasticsearch index mappings (check connectivity/permissions): %w", err)
 	}
 
 	result, err := parseResponse(ctx, res)
@@ -386,7 +391,7 @@ func (e *Client) GetMappings(ctx context.Context, indices []string) (mappings ma
 
 	mappings, ok := result.(map[string]interface{})
 	if !ok {
-		return nil, errors.New("failed to convert mappings to map[string]interface{}")
+		return nil, errors.New("failed to parse the elasticsearch mappings response (unexpected format)")
 	}
 
 	return mappings, nil
@@ -401,26 +406,75 @@ func parseResponse(ctx context.Context, res *esapi.Response) (interface{}, error
 	if res.IsError() {
 		var e map[string]interface{}
 		if err := json.NewDecoder(res.Body).Decode(&e); err != nil {
-			return nil, fmt.Errorf("error parsing the response body: %s", err)
-		} else {
-			// Print the response status and error information.
-			root_cause, _ := e["error"].(map[string]interface{})["root_cause"].([]interface{})[0].(map[string]interface{})
-			errMsg := fmt.Sprintf("[%s] %s: %s",
-				res.Status(),
-				root_cause["type"],
-				root_cause["reason"],
-			)
-			logger.DebugContext(ctx, "Response Details", "response", e)
-			return nil, errors.New(errMsg)
+			// The error response body itself failed to decode; keep raw err at DEBUG.
+			logger.DebugContext(ctx, "failed to parse elasticsearch error response body", "status", res.StatusCode, "error", err)
+			return nil, fmt.Errorf("failed to parse the elasticsearch response (HTTP %s); see debug logs: %w", res.Status(), err)
 		}
+		// Keep the full ES error object (which may include root_cause.reason, field
+		// values, and other potentially sensitive detail) at DEBUG only. Never
+		// surface it to the consumer.
+		logger.DebugContext(ctx, "Response Details", "response", e)
+
+		// Extract the error category (root_cause.type) defensively; it is a safe,
+		// non-sensitive classifier unlike root_cause.reason.
+		causeType := extractRootCauseType(e)
+		guidance := guidanceForRootCauseType(causeType)
+		if guidance != "" {
+			return nil, fmt.Errorf("elasticsearch rejected the request: %s - %s (HTTP %s); see debug logs for details", causeType, guidance, res.Status())
+		}
+		return nil, fmt.Errorf("elasticsearch rejected the request: %s (HTTP %s); see debug logs for details", causeType, res.Status())
 	}
 
 	var result interface{}
 	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("error parsing the response body: %s", err)
+		logger.DebugContext(ctx, "failed to parse elasticsearch response body", "status", res.StatusCode, "error", err)
+		return nil, fmt.Errorf("failed to parse the elasticsearch response (HTTP %s); see debug logs: %w", res.Status(), err)
 	}
 
 	return result, nil
+}
+
+// extractRootCauseType safely pulls error.root_cause[0].type out of a decoded
+// Elasticsearch error response. It returns "unknown" when the structure is not
+// present, so a malformed error body never panics. Only the non-sensitive type
+// classifier is returned; root_cause.reason is intentionally never extracted.
+func extractRootCauseType(e map[string]interface{}) string {
+	errObj, ok := e["error"].(map[string]interface{})
+	if !ok {
+		return "unknown"
+	}
+	rootCauses, ok := errObj["root_cause"].([]interface{})
+	if !ok || len(rootCauses) == 0 {
+		// Fall back to the top-level error.type when root_cause is absent.
+		if t, ok := errObj["type"].(string); ok && t != "" {
+			return t
+		}
+		return "unknown"
+	}
+	rootCause, ok := rootCauses[0].(map[string]interface{})
+	if !ok {
+		return "unknown"
+	}
+	if t, ok := rootCause["type"].(string); ok && t != "" {
+		return t
+	}
+	return "unknown"
+}
+
+// guidanceForRootCauseType maps common Elasticsearch root_cause types to fixed,
+// non-sensitive remediation guidance. Returns "" when no specific guidance is
+// known for the type.
+func guidanceForRootCauseType(causeType string) string {
+	switch causeType {
+	case "security_exception":
+		return "authorization failed"
+	case "index_not_found_exception":
+		return "index does not exist"
+	case "parsing_exception", "x_content_parse_exception":
+		return "the generated query was invalid"
+	default:
+		return ""
+	}
 }
 
 // GetInfo retrieves information about Elasticsearch.
@@ -428,7 +482,7 @@ func (e *Client) GetInfo(ctx context.Context) (interface{}, error) {
 	req := esapi.InfoRequest{}
 	res, err := req.Do(ctx, e.client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting elasticsearch information: %s", err)
+		return nil, fmt.Errorf("failed to get elasticsearch cluster information (check connectivity/permissions): %w", err)
 	}
 
 	result, err := parseResponse(ctx, res)

--- a/elasticsearch/client_pii_test.go
+++ b/elasticsearch/client_pii_test.go
@@ -1,0 +1,166 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// sensitiveSentinel is a stand-in for any PII / sensitive value that an
+// Elasticsearch error response might echo back (a field value from the query,
+// a document fragment in root_cause.reason, etc). The consumer-facing error
+// must NEVER contain it; it may only appear in DEBUG logs.
+const sensitiveSentinel = "SENSITIVE_FIELD_VALUE"
+
+// newDebugLogBuffer redirects the default slog logger to a debug-level JSON
+// buffer (GetLogger falls back to slog.Default when the context has no logger)
+// and returns the buffer plus a restore func.
+func newDebugLogBuffer(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return &buf, func() { slog.SetDefault(prev) }
+}
+
+// TestParseResponseDoesNotLeakRootCauseReason feeds parseResponse an
+// Elasticsearch error body whose root_cause.reason embeds a sensitive sentinel
+// and asserts:
+//
+//   - the returned consumer-facing error does NOT contain the sentinel,
+//
+//   - the returned error DOES carry the safe category (root_cause.type) and
+//     mapped guidance,
+//
+//   - the full ES error object (with the sentinel) is captured at DEBUG only.
+//
+//     go test -v -run TestParseResponseDoesNotLeakRootCauseReason ./elasticsearch/
+func TestParseResponseDoesNotLeakRootCauseReason(t *testing.T) {
+	logBuf, restore := newDebugLogBuffer(t)
+	defer restore()
+
+	esError := map[string]interface{}{
+		"error": map[string]interface{}{
+			"root_cause": []interface{}{
+				map[string]interface{}{
+					"type":   "security_exception",
+					"reason": "action [indices:data/read/search] is unauthorized for user [" + sensitiveSentinel + "]",
+				},
+			},
+			"type":   "security_exception",
+			"reason": "action [indices:data/read/search] is unauthorized for user [" + sensitiveSentinel + "]",
+		},
+		"status": 403,
+	}
+	bodyBytes, err := json.Marshal(esError)
+	if err != nil {
+		t.Fatalf("failed to marshal fake es error: %v", err)
+	}
+
+	res := &esapi.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+	}
+
+	_, gotErr := parseResponse(context.Background(), res)
+	if gotErr == nil {
+		t.Fatal("expected an error from parseResponse on an error response, got nil")
+	}
+
+	errStr := gotErr.Error()
+	if strings.Contains(errStr, sensitiveSentinel) {
+		t.Fatalf("consumer-facing error LEAKED the sensitive sentinel: %q", errStr)
+	}
+	// The safe category and mapped guidance should be present.
+	if !strings.Contains(errStr, "security_exception") {
+		t.Errorf("expected the safe root_cause.type category in the error, got: %q", errStr)
+	}
+	if !strings.Contains(errStr, "authorization failed") {
+		t.Errorf("expected mapped guidance for security_exception, got: %q", errStr)
+	}
+
+	// The sentinel MUST be present in the DEBUG logs (intentional detail).
+	logs := logBuf.String()
+	if !strings.Contains(logs, sensitiveSentinel) {
+		t.Errorf("expected the full ES error object (with sentinel) in DEBUG logs, not found in:\n%s", logs)
+	}
+}
+
+// newErrorES returns a fake Elasticsearch server that authenticates (HEAD / and
+// GET /) successfully but returns a non-401 error response for every _search,
+// with a body that embeds the sensitive sentinel inside root_cause.reason.
+func newErrorES(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"version":{"number":"8.0.0"}}`))
+		default:
+			// Non-401 error response carrying a sensitive value in the body.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"root_cause":[{"type":"x_content_parse_exception","reason":"failed to parse value [` + sensitiveSentinel + `]"}],"type":"x_content_parse_exception","reason":"failed to parse value [` + sensitiveSentinel + `]"},"status":400}`))
+		}
+	}))
+}
+
+// TestSearchErrorResponseDoesNotLeakBody exercises the end-to-end search path
+// against a fake cluster that returns a non-401 error response whose body
+// contains the sensitive sentinel. It asserts the consumer-facing error does
+// NOT contain the raw body / sentinel, while the raw body IS captured at DEBUG.
+//
+//	go test -v -run TestSearchErrorResponseDoesNotLeakBody ./elasticsearch/
+func TestSearchErrorResponseDoesNotLeakBody(t *testing.T) {
+	server := newErrorES(t)
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	logBuf, restore := newDebugLogBuffer(t)
+	defer restore()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	query := map[string]interface{}{
+		"query": map[string]interface{}{"term": map[string]interface{}{"customer_id": "JPMC-42"}},
+	}
+	_, gotErr := client.Search(ctx, "transactions", query)
+	if gotErr == nil {
+		t.Fatal("expected an error from Search on an error response, got nil")
+	}
+
+	errStr := gotErr.Error()
+	if strings.Contains(errStr, sensitiveSentinel) {
+		t.Fatalf("consumer-facing search error LEAKED the sensitive sentinel: %q", errStr)
+	}
+	// The consumer-facing error should carry the safe HTTP status classifier.
+	if !strings.Contains(errStr, "400") {
+		t.Errorf("expected the HTTP status in the consumer-facing error, got: %q", errStr)
+	}
+
+	// The raw response body (with the sentinel) MUST be present at DEBUG only.
+	logs := logBuf.String()
+	if !strings.Contains(logs, sensitiveSentinel) {
+		t.Errorf("expected the raw error body (with sentinel) in DEBUG logs, not found in:\n%s", logs)
+	}
+	if !strings.Contains(logs, `"msg":"es search error response"`) {
+		t.Errorf("expected the debug-level 'es search error response' log line, not found in:\n%s", logs)
+	}
+}


### PR DESCRIPTION
## Summary

Two independent, owner-requested fixes to `elasticsearch/client.go`, building on the already-merged **#118** (401-retry empty-body) and **#120** (per-attempt `body` → `body_bytes`). Both prerequisites were confirmed present on `main` before editing.

Context: JPMorgan Chase support ticket **#15000** · thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/ff214ba1-1075-444d-a3ba-56f11ed6c3d8

### A) Actionable errors (two-tier pattern)
Opaque, non-actionable errors (`internal error`, `error: %s`, `error while querying: %s`) are replaced with a consistent two-tier pattern:

- **Consumer-facing** error = HTTP status + an error **category** + a one-line "what to do", using only non-sensitive identifiers. Never `res.String()`, raw ES bodies, `root_cause.reason`, query body, field values, or credentials.
- **Internal detail** (raw `err`, `res.String()`, full ES error object) → `logger.DebugContext(...)` **only**.
- All wrapped errors switched `%s` → `%w` so `errors.Is/As` works.

Covers `NewClient`, the five `Authenticate` failure classes, `Ping`, `search` (transport / post-401 reauth / post-401 retry / non-401 error response), `parseResponse`, `GetIndices`, `GetAliases`, `GetMappings`, `GetInfo`, and the `Search`/`ExplainSearch` encode paths.

`parseResponse` no longer returns `root_cause.reason` verbatim — it returns the safe `root_cause.type` **category** plus mapped guidance (`security_exception` → "authorization failed", `index_not_found_exception` → "index does not exist", `parsing_exception`/`x_content_parse_exception` → "the generated query was invalid"), via new `extractRootCauseType` / `guidanceForRootCauseType` helpers that also replace the old unchecked `.([]interface{})[0]` chain (no more panic on malformed bodies). The full ES error object is logged at DEBUG only.

`Ping` now takes a `context.Context` so it can log the raw error response at DEBUG; callers in `Authenticate` and `connector.HealthCheck` are updated.

> Why it matters: `connector/query.go` and `connector/query_explain.go` surface `client.Search` failures to consumers via `UnprocessableContentError(..., {"error": err.Error()})`. Sanitizing the error at the source makes that consumer-facing payload PII-safe.

### B) Log / error PII sweep
Swept **every** `logger.*Context` / `slog` / span-event call across the connector (not just client.go):

- **Killed** the two `res.String()` leaks into consumer-facing errors (`Ping` error response, `search` non-401 error response). Both now log the raw body at **DEBUG only**.
- Confirmed #120's length-only `body_bytes` per-attempt logging is preserved; **no** body logging reintroduced at any non-DEBUG level.
- The full ES error object / raw bodies appear only at `DebugContext` and are never promoted into a returned error.
- No credentials / API keys / passwords / auth headers are logged anywhere.
- `addSpanEvent` (query.go / query_explain.go) logs variables / query / response at **DEBUG** level — intentional and acceptable per the agreed rule.
- **Flagged (not changed, out of scope):** `connector/telemetry.go:setDatabaseAttribute` sets the span attribute `db.statement` to the full query *unconditionally* (trace telemetry, a separate channel from logs/consumer errors, pre-existing). Left for a maintainer decision to keep this PR tight.

### New test
`elasticsearch/client_pii_test.go` (sentinel `SENSITIVE_FIELD_VALUE`):
- `TestParseResponseDoesNotLeakRootCauseReason` — `parseResponse` error does not contain the sentinel, carries the safe category + guidance, and the full object appears in DEBUG logs.
- `TestSearchErrorResponseDoesNotLeakBody` — end-to-end non-401 (HTTP 400) error response; consumer-facing `Search` error excludes the sentinel (includes `400`), raw body captured in the `"es search error response"` DEBUG line.

Existing `TestSearchRetryBodyOn401` and `TestSearchPerAttemptLogging` remain green.

```
go test -v -run 'TestParseResponseDoesNotLeakRootCauseReason|TestSearchErrorResponseDoesNotLeakBody' ./elasticsearch/
```

### Checks
`go build ./...` ✅ · `go vet ./...` ✅ · `gofmt -l` clean on changed files ✅ · `go test ./...` ✅ all pass. (Pre-existing unrelated gofmt drift in `connector/` left untouched; SonarCloud ignored per instructions.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
