### PR TITLE
docs: update changelog for v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.3]
+
+- Fix dropped query body on 401 retry — Elasticsearch was receiving an empty body on reauthentication retries, silently returning unfiltered results. ([#118](https://github.com/hasura/ndc-elasticsearch/pull/118))
+- Replace raw query body debug logging with payload size to avoid PII exposure in filter values. ([#120](https://github.com/hasura/ndc-elasticsearch/pull/120))
+
 ## [1.10.2]
 
 - Fix reported vulnerabilities.


### PR DESCRIPTION
## Summary

Adds the `v1.10.3` changelog entry covering:
- #118 — Fix dropped query body on 401 retry
- #120 — Replace raw query body logging with payload size to avoid PII exposure

## Release steps after merge

```
git tag v1.10.3 && git push origin v1.10.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)