### PR TITLE
fix(client): prevent concurrent-reauth data race on e.client

### DIFF
--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
@@ -20,7 +22,24 @@ import (
 )
 
 type Client struct {
-	client *elasticsearch.Client
+	// client is accessed by many concurrent goroutines (one per query) and
+	// replaced on reauthentication. atomic.Pointer gives lock-free reads while
+	// keeping writes safe.
+	client atomic.Pointer[elasticsearch.Client]
+
+	// reauthMu serializes credential refreshes. When multiple goroutines receive
+	// HTTP 401 simultaneously, only the first one to acquire this lock actually
+	// calls Reauthenticate; the rest wait, then detect that e.client has already
+	// been replaced and skip straight to the retry.
+	reauthMu sync.Mutex
+}
+
+func (e *Client) getClient() *elasticsearch.Client {
+	return e.client.Load()
+}
+
+func (e *Client) setClient(c *elasticsearch.Client) {
+	e.client.Store(c)
 }
 
 // NewClient creates a new client with configuration from cfg.
@@ -59,9 +78,9 @@ func (e *Client) Authenticate(ctx context.Context) error {
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
 		return errors.New("internal error")
 	}
-	e.client = esClient
+	e.setClient(esClient)
 	// Ping the client to check if the connection is successful
-	err = e.Ping()
+	err = pingClient(esClient)
 	if err == nil {
 		// authenticated successfully
 		return nil
@@ -87,9 +106,9 @@ func (e *Client) Authenticate(ctx context.Context) error {
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
 		return errors.New("internal error")
 	}
-	e.client = esClient
+	e.setClient(esClient)
 	// Ping the client to check if the connection is successful
-	err = e.Ping()
+	err = pingClient(esClient)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to ping elasticsearch")
 		logger.DebugContext(ctx, "elasticsearch ping error", "error", err)
@@ -125,16 +144,22 @@ func (e *Client) accquireAuthConfig(ctx context.Context, forceRefresh bool) (*el
 
 // Ping returns whether the Elasticsearch cluster is running.
 func (e *Client) Ping() error {
-	res, err := e.client.Ping()
+	return pingClient(e.getClient())
+}
+
+// pingClient pings c directly, without touching the Client wrapper.
+// Authenticate calls this with the freshly-created *elasticsearch.Client so
+// that it pings the specific instance it just built rather than whatever
+// e.client happens to hold at call time.
+func pingClient(c *elasticsearch.Client) error {
+	res, err := c.Ping()
 	if err != nil {
 		return fmt.Errorf("failed to ping elasticsearch: %w", err)
 	}
+	defer res.Body.Close()
 	if res.IsError() {
 		return fmt.Errorf("failed to ping elasticsearch: %s", res.String())
 	}
-
-	defer res.Body.Close()
-
 	return nil
 }
 
@@ -188,34 +213,43 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 	}
 	index := strings.Join(req.Index, ",")
 
-	// First attempt.
+	// Snapshot the client pointer used for this attempt. On a 401 we compare
+	// this snapshot against the current pointer to decide whether another
+	// goroutine already reauthenticated while we were waiting for reauthMu.
+	firstClient := e.getClient()
+
 	req.Body = bytes.NewReader(body)
 	logger.DebugContext(ctx, "Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
-	res, err := req.Do(ctx, e.client)
 	// Check the transport error before touching res: on a transport-level
 	// failure res is nil and res.IsError() would panic.
+	res, err := req.Do(ctx, firstClient)
 	if err != nil {
 		return nil, fmt.Errorf("error while querying: %s", err)
 	}
 
 	if res.IsError() {
-		if res.StatusCode == 401 {
-			// Unauthorized error, reauthenticate and retry.
-			if err = e.Reauthenticate(ctx); err != nil {
-				return nil, fmt.Errorf("error: %s", err)
-			}
-			// Rebuild the body so the retried request carries the same query
-			// instead of the already-drained (empty) reader. The retried reader
-			// holds exactly these bytes, so logging string(body) reflects what is
-			// actually sent over the wire.
-			req.Body = bytes.NewReader(body)
-			logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
-			res, err = req.Do(ctx, e.client)
-			if err != nil {
-				return nil, fmt.Errorf("error: %s", err)
-			}
-		} else {
+		if res.StatusCode != 401 {
 			return nil, fmt.Errorf("error while querying: %s", res.String())
+		}
+
+		// Serialize reauthentication: only one goroutine refreshes credentials;
+		// others wait here and then detect that e.client was already replaced.
+		e.reauthMu.Lock()
+		if e.getClient() == firstClient {
+			// Client hasn't been replaced yet — this goroutine does the reauth.
+			if err = e.Reauthenticate(ctx); err != nil {
+				e.reauthMu.Unlock()
+				return nil, fmt.Errorf("error: %s", err)
+			}
+		}
+		retryClient := e.getClient()
+		e.reauthMu.Unlock()
+
+		req.Body = bytes.NewReader(body)
+		logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
+		res, err = req.Do(ctx, retryClient)
+		if err != nil {
+			return nil, fmt.Errorf("error: %s", err)
 		}
 	}
 	return res, err
@@ -289,7 +323,7 @@ func (e *Client) GetIndices(ctx context.Context) ([]string, error) {
 	}
 
 	// Perform the request
-	res, err := req.Do(context.Background(), e.client)
+	res, err := req.Do(context.Background(), e.getClient())
 	if err != nil {
 		return nil, fmt.Errorf("error getting indices: %s", err)
 	}
@@ -322,7 +356,7 @@ func (e *Client) GetAliases(ctx context.Context) (aliasToIndexMap map[string]str
 	}
 
 	// Perform the request
-	res, err := req.Do(context.Background(), e.client)
+	res, err := req.Do(context.Background(), e.getClient())
 	if err != nil {
 		return nil, fmt.Errorf("error getting aliases: %s", err)
 	}
@@ -374,7 +408,7 @@ func (e *Client) GetMappings(ctx context.Context, indices []string) (mappings ma
 	}
 
 	// Perform the request
-	res, err := req.Do(context.Background(), e.client)
+	res, err := req.Do(context.Background(), e.getClient())
 	if err != nil {
 		return nil, fmt.Errorf("error getting mappings: %s", err)
 	}
@@ -426,7 +460,7 @@ func parseResponse(ctx context.Context, res *esapi.Response) (interface{}, error
 // GetInfo retrieves information about Elasticsearch.
 func (e *Client) GetInfo(ctx context.Context) (interface{}, error) {
 	req := esapi.InfoRequest{}
-	res, err := req.Do(ctx, e.client)
+	res, err := req.Do(ctx, e.getClient())
 	if err != nil {
 		return nil, fmt.Errorf("error getting elasticsearch information: %s", err)
 	}

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -82,7 +82,7 @@ func (e *Client) Authenticate(ctx context.Context) error {
 	// Ping the client to check if the connection is successful
 	err = pingClient(esClient)
 	if err == nil {
-		// authenticated successfully
+		logger.DebugContext(ctx, "authentication successful")
 		return nil
 	}
 
@@ -121,7 +121,18 @@ func (e *Client) Authenticate(ctx context.Context) error {
 }
 
 func (e *Client) Reauthenticate(ctx context.Context) error {
-	return e.Authenticate(ctx)
+	logger := connector.GetLogger(ctx)
+	logger.DebugContext(ctx, "reauthenticating after 401")
+	ctx, span := otel.Tracer("es_client").Start(ctx, "reauthenticate_elasticsearch", trace.WithAttributes(
+		attribute.String("internal.visibility", "user"),
+		attribute.String("trigger", "http_401"),
+	))
+	defer span.End()
+	if err := e.Authenticate(ctx); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 func (e *Client) accquireAuthConfig(ctx context.Context, forceRefresh bool) (*elasticsearch.Config, error) {
@@ -232,20 +243,36 @@ func (e *Client) search(ctx context.Context, o ...func(*esapi.SearchRequest)) (*
 			return nil, fmt.Errorf("error while querying: %s", res.String())
 		}
 
+		span := trace.SpanFromContext(ctx)
+		span.AddEvent("http_401_received", trace.WithAttributes(attribute.String("index", index)))
+		logger.DebugContext(ctx, "401 received, acquiring reauth lock", "index", index)
+
 		// Serialize reauthentication: only one goroutine refreshes credentials;
 		// others wait here and then detect that e.client was already replaced.
 		e.reauthMu.Lock()
 		if e.getClient() == firstClient {
 			// Client hasn't been replaced yet — this goroutine does the reauth.
+			span.AddEvent("reauth_started")
 			if err = e.Reauthenticate(ctx); err != nil {
 				e.reauthMu.Unlock()
+				span.SetStatus(codes.Error, err.Error())
 				return nil, fmt.Errorf("error: %s", err)
 			}
+			span.AddEvent("reauth_completed")
+		} else {
+			// Another concurrent goroutine already rotated the client while we
+			// were waiting for reauthMu — skip the refresh and go straight to
+			// the retry with the already-replaced client.
+			span.AddEvent("reauth_skipped", trace.WithAttributes(
+				attribute.String("reason", "completed_by_concurrent_goroutine"),
+			))
+			logger.DebugContext(ctx, "reauth already completed by concurrent goroutine, retrying", "index", index)
 		}
 		retryClient := e.getClient()
 		e.reauthMu.Unlock()
 
 		req.Body = bytes.NewReader(body)
+		span.AddEvent("retrying_after_reauth", trace.WithAttributes(attribute.String("index", index)))
 		logger.DebugContext(ctx, "Retry Query", "index", index, "body_bytes", req.Body.(*bytes.Reader).Len())
 		res, err = req.Do(ctx, retryClient)
 		if err != nil {

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -78,10 +78,14 @@ func (e *Client) Authenticate(ctx context.Context) error {
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
 		return errors.New("internal error")
 	}
-	e.setClient(esClient)
-	// Ping the client to check if the connection is successful
+	// Validate before publishing: ping first, then setClient. This ensures
+	// getClient() never vends an unvalidated client to concurrent goroutines,
+	// which also prevents a spurious second reauth when another goroutine
+	// snapshots a freshly-stored-but-not-yet-pinged client and mistakes it for
+	// the stale one that caused the original 401.
 	err = pingClient(esClient)
 	if err == nil {
+		e.setClient(esClient)
 		logger.DebugContext(ctx, "authentication successful")
 		return nil
 	}
@@ -106,8 +110,6 @@ func (e *Client) Authenticate(ctx context.Context) error {
 		span.RecordError(fmt.Errorf("failed to create elasticsearch client: %w", err))
 		return errors.New("internal error")
 	}
-	e.setClient(esClient)
-	// Ping the client to check if the connection is successful
 	err = pingClient(esClient)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to ping elasticsearch")
@@ -116,7 +118,8 @@ func (e *Client) Authenticate(ctx context.Context) error {
 		span.RecordError(fmt.Errorf("failed to ping elasticsearch: %w", err))
 		return errors.New("internal error")
 	}
-
+	e.setClient(esClient)
+	logger.DebugContext(ctx, "authentication successful")
 	return nil
 }
 

--- a/elasticsearch/client_retry_test.go
+++ b/elasticsearch/client_retry_test.go
@@ -11,7 +11,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // newFakeES returns an httptest server that emulates an Elasticsearch cluster
@@ -239,4 +242,378 @@ func trimWS(s string) string {
 		}
 	}
 	return string(out)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for concurrent tests
+// ---------------------------------------------------------------------------
+
+// reauthTrackingServer builds a fake ES server where:
+//   - HEAD / succeeds always (Ping).
+//   - GET / returns a minimal version doc (client init).
+//   - All other paths (_search) return HTTP 401 until reauthDone is set, then
+//     HTTP 200. reauthDone is set atomically the moment the *first* HEAD /
+//     arrives after setup is marked complete, so it flips exactly once — during
+//     the single reauthentication that should happen under the fix.
+//
+// pingCount counts HEAD / requests received after setupDone is set; it must
+// equal 1 for the test to pass (exactly one reauthentication).
+// bodies collects the raw body of every _search request received.
+func reauthTrackingServer(
+	t *testing.T,
+	setupDone *atomic.Bool,
+	reauthDone *atomic.Bool,
+	pingCount *atomic.Int32,
+	mu *sync.Mutex,
+	bodies *[]string,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/":
+			if setupDone.Load() {
+				pingCount.Add(1)
+				reauthDone.Store(true)
+			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"version":{"number":"8.0.0"}}`))
+		default:
+			b, _ := io.ReadAll(r.Body)
+			if mu != nil {
+				mu.Lock()
+				*bodies = append(*bodies, string(b))
+				mu.Unlock()
+			}
+			if !reauthDone.Load() {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"took":1,"hits":{"total":{"value":0},"hits":[]}}`))
+		}
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// TestConcurrentSearchSingleReauth — the thundering-herd test
+// ---------------------------------------------------------------------------
+
+// TestConcurrentSearchSingleReauth fires N goroutines that all receive HTTP 401
+// on their first _search attempt (token expired). Under the fix, reauthMu
+// ensures only ONE goroutine calls Reauthenticate; the others wait, detect that
+// e.client has already been replaced, and skip straight to their retry.
+//
+// Assertions:
+//  1. Every goroutine's Search() call succeeds (no errors).
+//  2. Exactly one reauthentication (one POST-setup Ping) occurred.
+//
+// Without the fix (no reauthMu), all N goroutines would race to write
+// e.client simultaneously, triggering the race detector and potentially causing
+// redundant — or conflicting — credential refreshes.
+//
+//	go test -v -race -run TestConcurrentSearchSingleReauth ./elasticsearch/
+func TestConcurrentSearchSingleReauth(t *testing.T) {
+	const N = 20
+
+	var (
+		setupDone  atomic.Bool
+		reauthDone atomic.Bool
+		pingCount  atomic.Int32
+		mu         sync.Mutex
+		bodies     []string
+	)
+
+	server := reauthTrackingServer(t, &setupDone, &reauthDone, &pingCount, &mu, &bodies)
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+	setupDone.Store(true)
+
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	for i := range N {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			q := map[string]interface{}{
+				"query": map[string]interface{}{
+					"term": map[string]interface{}{"goroutine": i},
+				},
+			}
+			_, errs[i] = client.Search(ctx, "idx", q)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoError(t, e, "goroutine %d returned an error", i)
+	}
+
+	got := int(pingCount.Load())
+	if got != 1 {
+		t.Errorf("expected exactly 1 reauthentication, got %d — thundering herd not prevented", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestConcurrentSearchBodiesPreserved
+// ---------------------------------------------------------------------------
+
+// TestConcurrentSearchBodiesPreserved verifies that each goroutine's retry
+// carries its own, non-empty query body — not an empty payload and not another
+// goroutine's query. It uses the same reauthDone flip mechanism so all first
+// attempts get 401 and all retries get 200.
+//
+//	go test -v -race -run TestConcurrentSearchBodiesPreserved ./elasticsearch/
+func TestConcurrentSearchBodiesPreserved(t *testing.T) {
+	const N = 10
+
+	var (
+		setupDone  atomic.Bool
+		reauthDone atomic.Bool
+		pingCount  atomic.Int32
+		mu         sync.Mutex
+		bodies     []string
+	)
+
+	server := reauthTrackingServer(t, &setupDone, &reauthDone, &pingCount, &mu, &bodies)
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+	setupDone.Store(true)
+
+	// Build N queries, each uniquely identified by goroutine_id.
+	queries := make([]map[string]interface{}, N)
+	for i := range queries {
+		queries[i] = map[string]interface{}{
+			"query": map[string]interface{}{
+				"term": map[string]interface{}{"goroutine_id": i},
+			},
+		}
+	}
+
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	for i := range N {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = client.Search(ctx, "idx", queries[i])
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoError(t, e, "goroutine %d returned an error", i)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), bodies...)
+	mu.Unlock()
+
+	// No attempt — first or retry — may ever send an empty body.
+	for i, b := range got {
+		if len(trimWS(b)) == 0 {
+			t.Errorf("attempt %d sent an empty body; ES would treat this as match_all", i)
+		}
+	}
+
+	// Every goroutine's query must appear at least once among the received
+	// bodies. If a retry dropped the body the query would be absent.
+	for i, q := range queries {
+		encoded, _ := json.Marshal(q)
+		found := false
+		for _, b := range got {
+			if jsonEqual(t, b, string(encoded)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("goroutine %d query not found in any received body; query was dropped", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSearchTransportError
+// ---------------------------------------------------------------------------
+
+// TestSearchTransportError verifies that a transport-level failure on the first
+// attempt (the TCP connection is closed abruptly, so req.Do returns err != nil
+// and res == nil) is surfaced as an error rather than causing a nil-pointer
+// panic on res.IsError().
+//
+//	go test -v -run TestSearchTransportError ./elasticsearch/
+func TestSearchTransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"version":{"number":"8.0.0"}}`))
+		default:
+			// Abruptly close the connection to produce a transport error.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Search(ctx, "idx", map[string]interface{}{
+		"query": map[string]interface{}{"match_all": map[string]interface{}{}},
+	})
+	if err == nil {
+		t.Fatal("expected an error on transport failure, got nil")
+	}
+	t.Logf("got expected transport error: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// TestSearchReauthFails
+// ---------------------------------------------------------------------------
+
+// TestSearchReauthFails verifies that when a _search returns 401 and the
+// subsequent Reauthenticate call itself fails (the Ping during Authenticate
+// also returns a non-2xx), Search surfaces an error rather than retrying with
+// a stale or nil client.
+//
+//	go test -v -run TestSearchReauthFails ./elasticsearch/
+func TestSearchReauthFails(t *testing.T) {
+	// Allow the initial NewClient ping to succeed (count == 1), then fail all
+	// subsequent pings so that Reauthenticate cannot complete.
+	var pingCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/":
+			n := int(pingCount.Add(1))
+			if n == 1 {
+				// Initial setup ping — succeed.
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			// All subsequent pings (reauth attempts) — fail.
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"version":{"number":"8.0.0"}}`))
+		default:
+			// Every _search returns 401 to trigger reauthentication.
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+
+	_, err = client.Search(ctx, "idx", map[string]interface{}{
+		"query": map[string]interface{}{"term": map[string]interface{}{"id": "test"}},
+	})
+	if err == nil {
+		t.Fatal("expected Search to return an error when Reauthenticate fails, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+// ---------------------------------------------------------------------------
+// TestConcurrentSearchNoReauthIfClientAlreadyReplaced
+// ---------------------------------------------------------------------------
+
+// TestConcurrentSearchNoReauthIfClientAlreadyReplaced is the unit-level proof
+// of the "skip reauth if already replaced" logic. It checks that a goroutine
+// which arrives at reauthMu *after* another goroutine has already rotated the
+// client does NOT call Reauthenticate a second time.
+//
+// It does this by running two sequential waves of the same scenario:
+//   - Wave 1: first goroutine triggers a real reauth; second goroutine must
+//     detect the new client and skip.
+//   - Both goroutines must get successful responses.
+//
+// The ping-count assertion is inherited from TestConcurrentSearchSingleReauth;
+// here we concentrate on correctness for the two-goroutine case so failures
+// are easier to diagnose.
+//
+//	go test -v -race -run TestConcurrentSearchNoReauthIfClientAlreadyReplaced ./elasticsearch/
+func TestConcurrentSearchNoReauthIfClientAlreadyReplaced(t *testing.T) {
+	var (
+		setupDone  atomic.Bool
+		reauthDone atomic.Bool
+		pingCount  atomic.Int32
+	)
+
+	server := reauthTrackingServer(t, &setupDone, &reauthDone, &pingCount, nil, nil)
+	defer server.Close()
+
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("ELASTICSEARCH_USERNAME", "elastic")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "changeme")
+
+	ctx := context.Background()
+	client, err := NewClient(ctx)
+	require.NoError(t, err)
+	setupDone.Store(true)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = client.Search(ctx, "idx", map[string]interface{}{
+				"query": map[string]interface{}{"term": map[string]interface{}{"i": i}},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	for i, e := range errs {
+		require.NoError(t, e, "goroutine %d", i)
+	}
+	if got := int(pingCount.Load()); got != 1 {
+		t.Errorf("expected 1 reauthentication for 2 concurrent 401s, got %d", got)
+	}
 }


### PR DESCRIPTION
## Summary

- `e.client` was a plain pointer written by `Reauthenticate` and read by every concurrent search goroutine — a data race under `-race` and a source of redundant credential refreshes when multiple requests received HTTP 401 simultaneously (thundering herd on token expiry).
- `e.client` is now an `atomic.Pointer[elasticsearch.Client]` for lock-free, race-free reads on the hot search path.
- A new `reauthMu sync.Mutex` serializes reauthentication: the first goroutine to acquire it refreshes credentials; goroutines that arrive later compare their snapshotted client pointer against `e.getClient()` — if it changed, they skip the refresh and retry directly with the already-rotated client.
- All other `e.client` reads (`GetIndices`, `GetAliases`, `GetMappings`, `GetInfo`, `Ping`) updated to go through `getClient()`.
- `Authenticate` now calls `pingClient(esClient)` with the local variable it just built, so the ping is always tied to the specific instance being validated.

## New tests (all pass under `-race`)

| Test | What it proves |
|---|---|
| `TestConcurrentSearchSingleReauth` | 20 goroutines all see 401; exactly 1 reauthentication occurs |
| `TestConcurrentSearchBodiesPreserved` | Each goroutine's retry carries its own non-empty body — no leakage or drop across goroutines |
| `TestConcurrentSearchNoReauthIfClientAlreadyReplaced` | Focused 2-goroutine proof that the second arrival at `reauthMu` detects the already-replaced client and skips the redundant reauth |
| `TestSearchTransportError` | Transport-level failure (`res == nil`) surfaces as an error rather than panicking on `res.IsError()` |
| `TestSearchReauthFails` | When `Reauthenticate` itself fails, `Search` returns the error cleanly |

Existing `TestSearchRetryBodyOn401` and `TestSearchPerAttemptLogging` continue to pass, confirming the single-goroutine 401 retry behaviour is unchanged.

## Test plan

- [ ] `go test -race ./elasticsearch/` — all 7 tests pass, no races reported
- [ ] `go test -race ./...` — full suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)