### PR TITLE
fix(query): remove accidental request body logging

### DIFF
--- a/connector/query.go
+++ b/connector/query.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"maps"
 
 	"github.com/hasura/ndc-elasticsearch/elasticsearch"
@@ -214,10 +213,6 @@ func prepareElasticsearchQuery(ctx context.Context, request *schema.QueryRequest
 			query["query"] = filter
 		}
 	}
-
-	// Pretty print the query
-	queryJSON, _ := json.MarshalIndent(query, "", "  ")
-	fmt.Println(string(queryJSON))
 
 	return query, nil
 }


### PR DESCRIPTION
## Summary
- Removes a debug `fmt.Println` in `prepareElasticsearchQuery` that was printing the full Elasticsearch query body to stdout on every request

## Test plan
- [ ] Verify no query body is printed to stdout when running queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)