### PR TITLE
fix: prevent NDC object-type name collisions dropping nested fields

### DIFF
--- a/connector/fields_test.go
+++ b/connector/fields_test.go
@@ -29,6 +29,11 @@ var tests = []test{
 	{
 		name: "books_2",
 	},
+	{
+		// Single index with two distinct nested objects — no name collision.
+		// After the fix, unambiguous bare names must be preserved unchanged.
+		name: "nested_multi",
+	},
 }
 
 func TestSchema(t *testing.T) {

--- a/connector/schema.go
+++ b/connector/schema.go
@@ -2,18 +2,31 @@ package connector
 
 import (
 	"context"
+	"sort"
+	"strings"
 
 	"github.com/hasura/ndc-elasticsearch/internal"
 	"github.com/hasura/ndc-elasticsearch/types"
 	"github.com/hasura/ndc-sdk-go/schema"
 )
 
+// collectionObjects holds the intermediate field/object lists for a single
+// collection before name resolution. We collect all collections first, resolve
+// object-type names globally, then emit — this prevents the name-collision bug
+// where identically-named nested objects across indices (or within one index)
+// overwrote each other in the global ObjectTypes map and silently dropped fields.
+type collectionObjects struct {
+	name    string                   // index / native-query name
+	fields  []map[string]interface{} // top-level fields of the collection
+	objects []map[string]interface{} // all nested object types (flattened)
+}
+
 // GetSchema returns the schema by parsing the configuration.
 func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configuration, state *types.State) (schema.SchemaResponseMarshaler, error) {
 	return state.Schema, nil
 }
 
-// parseConfigurationToSchema parses the given configuration to generate the schema response.
+// ParseConfigurationToSchema parses the given configuration to generate the schema response.
 func ParseConfigurationToSchema(configuration *types.Configuration, state *types.State) *schema.SchemaResponse {
 	ndcSchema := schema.SchemaResponse{
 		ScalarTypes: make(schema.SchemaResponseScalarTypes),
@@ -24,6 +37,12 @@ func ParseConfigurationToSchema(configuration *types.Configuration, state *types
 	}
 
 	indices := configuration.Indices
+
+	// Phase 1: walk every index and collect fields/objects without emitting
+	// object types yet. reservedNames tracks names that a nested object type
+	// must not reuse as its bare name (index names and static type names).
+	collected := make([]collectionObjects, 0, len(indices))
+	reservedNames := make(map[string]bool)
 
 	for indexName, mappings := range indices {
 		state.SupportedFilterFields[indexName] = map[string]interface{}{
@@ -49,7 +68,8 @@ func ParseConfigurationToSchema(configuration *types.Configuration, state *types
 		}
 
 		fields, objects := getScalarTypesAndObjects(properties, state, indexName, "")
-		prepareNdcSchema(&ndcSchema, indexName, fields, objects)
+		collected = append(collected, collectionObjects{name: indexName, fields: fields, objects: objects})
+		reservedNames[indexName] = true
 
 		ndcSchema.Collections = append(ndcSchema.Collections, schema.CollectionInfo{
 			Name:                  indexName,
@@ -61,15 +81,99 @@ func ParseConfigurationToSchema(configuration *types.Configuration, state *types
 	}
 
 	nativeQueries := configuration.Queries
+	parseNativeQueryToSchema(&ndcSchema, state, nativeQueries, &collected, reservedNames)
 
-	ndcSchema = parseNativeQueryToSchema(&ndcSchema, state, nativeQueries)
+	// Phase 2: resolve object-type names globally. Bare name is kept when
+	// unambiguous; fully-qualified name (index.path.to.field) is used only
+	// when the bare name maps to two or more distinct structures.
+	resolution := resolveObjectTypeNames(collected, reservedNames)
+
+	// Phase 3: rewrite every object-type reference to its resolved name, then emit.
+	for _, c := range collected {
+		rewriteObjectFieldTypes(c.fields, resolution)
+		for _, obj := range c.objects {
+			rewriteObjectFieldTypes(obj["fields"].([]map[string]interface{}), resolution)
+			if qualified, ok := obj["name"].(string); ok {
+				if final, ok := resolution[qualified]; ok {
+					obj["name"] = final
+				}
+			}
+		}
+		prepareNdcSchema(&ndcSchema, c.name, c.fields, c.objects)
+	}
 
 	return &ndcSchema
 }
 
+// resolveObjectTypeNames builds a map from each object's fully-qualified name
+// to the name it should be emitted under.
+//
+// An object keeps its bare field name when that bare name maps to exactly one
+// distinct structure and does not collide with a reserved name. Otherwise every
+// object sharing that bare name is emitted under its fully-qualified name.
+func resolveObjectTypeNames(collected []collectionObjects, reservedNames map[string]bool) map[string]string {
+	// Add static type names so a nested object never shadows them.
+	for name := range internal.ScalarTypeMap {
+		reservedNames[name] = true
+	}
+	for name := range internal.ObjectTypeMap {
+		reservedNames[name] = true
+	}
+	for name := range internal.RequiredScalarTypes {
+		reservedNames[name] = true
+	}
+	for name := range internal.RequiredObjectTypes {
+		reservedNames[name] = true
+	}
+	reservedNames["_id"] = true
+
+	// Collect the set of distinct structural signatures seen per bare name.
+	signaturesByBareName := make(map[string]map[string]bool)
+	for _, c := range collected {
+		for _, obj := range c.objects {
+			bare := obj["bareName"].(string)
+			sig := obj["signature"].(string)
+			if signaturesByBareName[bare] == nil {
+				signaturesByBareName[bare] = make(map[string]bool)
+			}
+			signaturesByBareName[bare][sig] = true
+		}
+	}
+
+	resolution := make(map[string]string)
+	for _, c := range collected {
+		for _, obj := range c.objects {
+			qualified := obj["name"].(string)
+			bare := obj["bareName"].(string)
+			if len(signaturesByBareName[bare]) == 1 && !reservedNames[bare] {
+				resolution[qualified] = bare
+			} else {
+				resolution[qualified] = qualified
+			}
+		}
+	}
+	return resolution
+}
+
+// rewriteObjectFieldTypes replaces the type of every object field with its
+// resolved name. Scalar field types are not in the resolution map and are
+// left untouched.
+func rewriteObjectFieldTypes(fields []map[string]interface{}, resolution map[string]string) {
+	for _, field := range fields {
+		if _, isObject := field["obj"]; !isObject {
+			continue
+		}
+		if qualified, ok := field["type"].(string); ok {
+			if final, ok := resolution[qualified]; ok {
+				field["type"] = final
+			}
+		}
+	}
+}
+
 // parseNativeQueryToSchema parses the given native queries and adds them to the schema response.
 // It also handles return types of kind "defination" and updates the state accordingly.
-func parseNativeQueryToSchema(schemaResponse *schema.SchemaResponse, state *types.State, nativeQueries map[string]types.NativeQuery) schema.SchemaResponse {
+func parseNativeQueryToSchema(schemaResponse *schema.SchemaResponse, state *types.State, nativeQueries map[string]types.NativeQuery, collected *[]collectionObjects, reservedNames map[string]bool) {
 	for queryName, queryConfig := range nativeQueries {
 		indexName := queryConfig.Index
 
@@ -94,8 +198,10 @@ func parseNativeQueryToSchema(schemaResponse *schema.SchemaResponse, state *type
 			state.NestedFields[indexName] = make(map[string]string)
 			state.SupportedAggregateFields[indexName] = make(map[string]string)
 			state.SupportedSortFields[indexName] = make(map[string]string)
+			// Defer emission to phase 3 so native-query objects join global name resolution.
 			fields, objects := getScalarTypesAndObjects(properties, state, indexName, "")
-			prepareNdcSchema(schemaResponse, indexName, fields, objects)
+			*collected = append(*collected, collectionObjects{name: indexName, fields: fields, objects: objects})
+			reservedNames[indexName] = true
 		}
 
 		// Get arguments for the collection info
@@ -118,8 +224,6 @@ func parseNativeQueryToSchema(schemaResponse *schema.SchemaResponse, state *type
 
 		schemaResponse.Collections = append(schemaResponse.Collections, collectionInfo)
 	}
-
-	return *schemaResponse
 }
 
 // getNdcArguments converts the query parameters to NDC ArgumentInfo objects.
@@ -144,6 +248,9 @@ func getNdcArguments(parameters map[string]interface{}) schema.CollectionInfoArg
 }
 
 // getScalarTypesAndObjects retrieves scalar types and objects from properties.
+// Each nested object is tagged with a fully-qualified name (index.path.to.field),
+// a bare name (the field name alone), and a structural signature. Name resolution
+// happens later in resolveObjectTypeNames.
 func getScalarTypesAndObjects(properties map[string]interface{}, state *types.State, indexName string, parentField string) ([]map[string]interface{}, []map[string]interface{}) {
 	fields := make([]map[string]interface{}, 0)
 	objects := make([]map[string]interface{}, 0)
@@ -169,21 +276,55 @@ func getScalarTypesAndObjects(properties map[string]interface{}, state *types.St
 			if fieldType == "nested" {
 				state.NestedFields[indexName].(map[string]string)[fieldWithParent] = fieldType
 			}
-			fields = append(fields, map[string]interface{}{
-				"name": fieldName,
-				"type": fieldName,
-				"obj":  true,
-			})
 
 			flds, objs := getScalarTypesAndObjects(nestedObject, state, indexName, fieldWithParent)
+
+			// Qualify the name globally; resolution may later collapse it back to
+			// the bare field name when there is no ambiguity.
+			qualifiedName := indexName + "." + fieldWithParent
+			sig := objectSignature(flds)
+
+			fields = append(fields, map[string]interface{}{
+				"name":      fieldName,
+				"type":      qualifiedName,
+				"obj":       true,
+				"signature": sig,
+			})
+
 			objects = append(objects, map[string]interface{}{
-				"name":   fieldName,
-				"fields": flds,
+				"name":      qualifiedName,
+				"bareName":  fieldName,
+				"signature": sig,
+				"fields":    flds,
 			})
 			objects = append(objects, objs...)
 		}
 	}
 	return fields, objects
+}
+
+// objectSignature returns an order-independent, recursive fingerprint of an
+// object's fields. Two objects produce the same signature only when they have
+// identical field names, scalar types, and nested structures. It is used to
+// decide whether two objects sharing a bare field name are in fact the same
+// type (safe to collapse to a bare name) or different types (must be kept
+// under their fully-qualified names).
+func objectSignature(fields []map[string]interface{}) string {
+	parts := make([]string, 0, len(fields))
+	for _, field := range fields {
+		name, _ := field["name"].(string)
+		if _, isObject := field["obj"]; isObject {
+			// Embed the child's own signature so the fingerprint is recursive
+			// and independent of the (qualified) child type name.
+			childSig, _ := field["signature"].(string)
+			parts = append(parts, name+"=@{"+childSig+"}")
+		} else {
+			fieldType, _ := field["type"].(string)
+			parts = append(parts, name+"="+fieldType)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ";")
 }
 
 // prepareNdcSchema prepares the NDC schema. It takes in the NDC schema,
@@ -217,7 +358,7 @@ func prepareNdcSchema(ndcSchema *schema.SchemaResponse, index string, fields []m
 	// Add the required fields to the schema
 	ndcSchema.ScalarTypes["_id"] = internal.ScalarTypeMap["_id"]
 
-	// ADd the required scalar type to the schema
+	// Add the required scalar type to the schema
 	for scalarTypeName, ScalarType := range internal.RequiredScalarTypes {
 		ndcSchema.ScalarTypes[scalarTypeName] = ScalarType
 	}

--- a/connector/schema_collision_test.go
+++ b/connector/schema_collision_test.go
@@ -1,0 +1,330 @@
+package connector_test
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/hasura/ndc-elasticsearch/connector"
+	"github.com/hasura/ndc-elasticsearch/types"
+	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collisionState builds a minimal State from a configuration JSON literal.
+func collisionState(t *testing.T, configJSON string) (*types.Configuration, *types.State) {
+	t.Helper()
+	var cfg types.Configuration
+	require.NoError(t, json.Unmarshal([]byte(configJSON), &cfg))
+	st := &types.State{
+		SupportedSortFields:      make(map[string]interface{}),
+		SupportedAggregateFields: make(map[string]interface{}),
+		SupportedFilterFields:    make(map[string]interface{}),
+		NestedFields:             make(map[string]interface{}),
+		Configuration:            &cfg,
+	}
+	return &cfg, st
+}
+
+// nestedTypeName resolves the underlying named type of a nested field on a
+// collection object type, unwrapping array/nullable wrappers.
+func nestedTypeName(t *testing.T, resp *schema.SchemaResponse, collectionType, field string) string {
+	t.Helper()
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	objectTypes := m["object_types"].(map[string]interface{})
+	ot, ok := objectTypes[collectionType].(map[string]interface{})
+	require.Truef(t, ok, "object type %q not found", collectionType)
+	fields := ot["fields"].(map[string]interface{})
+	f, ok := fields[field].(map[string]interface{})
+	require.Truef(t, ok, "field %q not found on %q", field, collectionType)
+
+	typ := f["type"].(map[string]interface{})
+	for {
+		switch typ["type"].(string) {
+		case "named":
+			return typ["name"].(string)
+		case "array":
+			typ = typ["element_type"].(map[string]interface{})
+		case "nullable":
+			typ = typ["underlying_type"].(map[string]interface{})
+		default:
+			t.Fatalf("unexpected type kind %v", typ["type"])
+		}
+	}
+}
+
+// objectFieldNames returns the set of field names for a given object type.
+func objectFieldNames(t *testing.T, resp *schema.SchemaResponse, typeName string) map[string]bool {
+	t.Helper()
+	raw, err := json.Marshal(resp)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &m))
+
+	objectTypes := m["object_types"].(map[string]interface{})
+	ot, ok := objectTypes[typeName].(map[string]interface{})
+	require.Truef(t, ok, "object type %q not found", typeName)
+	out := map[string]bool{}
+	for name := range ot["fields"].(map[string]interface{}) {
+		out[name] = true
+	}
+	return out
+}
+
+// TestSchemaCollision_CrossIndexDifferentShapes documents the bug where two
+// indices each define a nested object with the same name but different fields.
+// Without the fix, one definition silently overwrites the other and fields are
+// dropped. With the fix, each collection must reference a distinct object type
+// that retains all of its fields.
+//
+// Mapping:
+//
+//	orders.address  → {street, city, country, postal_code}
+//	returns.address → {city, country}
+func TestSchemaCollision_CrossIndexDifferentShapes(t *testing.T) {
+	const cfgJSON = `{
+	  "indices": {
+	    "orders": {"mappings": {"properties": {
+	      "order_id": {"type": "keyword"},
+	      "address": {"type": "nested", "properties": {
+	        "street":      {"type": "text"},
+	        "city":        {"type": "keyword"},
+	        "country":     {"type": "keyword"},
+	        "postal_code": {"type": "keyword"}
+	      }}
+	    }}},
+	    "returns": {"mappings": {"properties": {
+	      "return_id": {"type": "keyword"},
+	      "address": {"type": "nested", "properties": {
+	        "city":    {"type": "keyword"},
+	        "country": {"type": "keyword"}
+	      }}
+	    }}}
+	  },
+	  "queries": {}
+	}`
+
+	cfg, st := collisionState(t, cfgJSON)
+	resp := connector.ParseConfigurationToSchema(cfg, st)
+
+	ordersAddrType := nestedTypeName(t, resp, "orders", "address")
+	returnsAddrType := nestedTypeName(t, resp, "returns", "address")
+
+	// The two address types have different structures — they must be separate
+	// object types; sharing one means fields will be dropped.
+	assert.NotEqual(t, ordersAddrType, returnsAddrType,
+		"colliding address types must be disambiguated into separate object types")
+
+	// orders.address must retain all four fields.
+	ordersFields := objectFieldNames(t, resp, ordersAddrType)
+	assert.True(t, ordersFields["street"], "orders.address must keep field 'street'")
+	assert.True(t, ordersFields["city"], "orders.address must keep field 'city'")
+	assert.True(t, ordersFields["country"], "orders.address must keep field 'country'")
+	assert.True(t, ordersFields["postal_code"], "orders.address must keep field 'postal_code'")
+
+	// returns.address must retain its two fields.
+	returnsFields := objectFieldNames(t, resp, returnsAddrType)
+	assert.True(t, returnsFields["city"], "returns.address must keep field 'city'")
+	assert.True(t, returnsFields["country"], "returns.address must keep field 'country'")
+	assert.Len(t, returnsFields, 2, "returns.address must have exactly 2 fields")
+}
+
+// TestSchemaCollision_CrossIndexIdenticalShapes verifies the minimal-churn
+// guarantee: two indices that share an identically-structured nested object
+// (e.g. an index and its alias) must collapse to a single bare-named object
+// type. The fix must not introduce needless renames in this case.
+func TestSchemaCollision_CrossIndexIdenticalShapes(t *testing.T) {
+	const cfgJSON = `{
+	  "indices": {
+	    "events": {"mappings": {"properties": {
+	      "event_type": {"type": "keyword"},
+	      "metadata": {"type": "nested", "properties": {
+	        "key":   {"type": "keyword"},
+	        "value": {"type": "text"}
+	      }}
+	    }}},
+	    "events_archive": {"mappings": {"properties": {
+	      "event_type": {"type": "keyword"},
+	      "metadata": {"type": "nested", "properties": {
+	        "key":   {"type": "keyword"},
+	        "value": {"type": "text"}
+	      }}
+	    }}}
+	  },
+	  "queries": {}
+	}`
+
+	cfg, st := collisionState(t, cfgJSON)
+	resp := connector.ParseConfigurationToSchema(cfg, st)
+
+	eventsMetaType := nestedTypeName(t, resp, "events", "metadata")
+	archiveMetaType := nestedTypeName(t, resp, "events_archive", "metadata")
+
+	// Identical structures must share a single bare-named type — no needless rename.
+	assert.Equal(t, "metadata", eventsMetaType, "events.metadata must use the bare name 'metadata'")
+	assert.Equal(t, "metadata", archiveMetaType, "events_archive.metadata must use the bare name 'metadata'")
+
+	fields := objectFieldNames(t, resp, "metadata")
+	assert.True(t, fields["key"], "metadata must have field 'key'")
+	assert.True(t, fields["value"], "metadata must have field 'value'")
+}
+
+// TestSchemaCollision_WithinIndex documents the within-index variant of the
+// bug: two top-level nested objects in the same index each contain a nested
+// child with the same field name but different structures. Without the fix,
+// both parent objects point at the same (corrupted) child type.
+//
+// Mapping (single index: profiles):
+//
+//	billing.contact  → {name, email, phone}
+//	shipping.contact → {name, email}
+func TestSchemaCollision_WithinIndex(t *testing.T) {
+	const cfgJSON = `{
+	  "indices": {
+	    "profiles": {"mappings": {"properties": {
+	      "user_id": {"type": "keyword"},
+	      "billing": {"type": "nested", "properties": {
+	        "contact": {"type": "nested", "properties": {
+	          "name":  {"type": "text"},
+	          "email": {"type": "keyword"},
+	          "phone": {"type": "keyword"}
+	        }}
+	      }},
+	      "shipping": {"type": "nested", "properties": {
+	        "contact": {"type": "nested", "properties": {
+	          "name":  {"type": "text"},
+	          "email": {"type": "keyword"}
+	        }}
+	      }}
+	    }}}
+	  },
+	  "queries": {}
+	}`
+
+	cfg, st := collisionState(t, cfgJSON)
+	resp := connector.ParseConfigurationToSchema(cfg, st)
+
+	billingContactType := nestedTypeName(t, resp, "billing", "contact")
+	shippingContactType := nestedTypeName(t, resp, "shipping", "contact")
+
+	// billing and shipping have structurally different contact children — they
+	// must not share a single object type.
+	assert.NotEqual(t, billingContactType, shippingContactType,
+		"billing.contact and shipping.contact have different shapes and must be separate object types")
+
+	// billing.contact must retain all three fields.
+	billingFields := objectFieldNames(t, resp, billingContactType)
+	assert.True(t, billingFields["name"], "billing.contact must keep field 'name'")
+	assert.True(t, billingFields["email"], "billing.contact must keep field 'email'")
+	assert.True(t, billingFields["phone"], "billing.contact must keep field 'phone'")
+
+	// shipping.contact must retain its two fields.
+	shippingFields := objectFieldNames(t, resp, shippingContactType)
+	assert.True(t, shippingFields["name"], "shipping.contact must keep field 'name'")
+	assert.True(t, shippingFields["email"], "shipping.contact must keep field 'email'")
+	assert.Len(t, shippingFields, 2, "shipping.contact must have exactly 2 fields")
+}
+
+// TestSchemaCollision_Deterministic guards against the Go map-iteration
+// nondeterminism that made the original bug intermittent. Running the schema
+// generator many times must always produce byte-identical object and scalar
+// type output.
+func TestSchemaCollision_Deterministic(t *testing.T) {
+	const cfgJSON = `{
+	  "indices": {
+	    "orders": {"mappings": {"properties": {
+	      "address": {"type": "nested", "properties": {
+	        "street":  {"type": "text"},
+	        "city":    {"type": "keyword"},
+	        "country": {"type": "keyword"}
+	      }}
+	    }}},
+	    "returns": {"mappings": {"properties": {
+	      "address": {"type": "nested", "properties": {
+	        "city":    {"type": "keyword"},
+	        "country": {"type": "keyword"}
+	      }}
+	    }}}
+	  },
+	  "queries": {}
+	}`
+
+	var first string
+	for i := 0; i < 50; i++ {
+		cfg, st := collisionState(t, cfgJSON)
+		resp := connector.ParseConfigurationToSchema(cfg, st)
+
+		// json.Marshal sorts map keys, so identical content → identical bytes.
+		objects, err := json.Marshal(resp.ObjectTypes)
+		require.NoError(t, err)
+		scalars, err := json.Marshal(resp.ScalarTypes)
+		require.NoError(t, err)
+		cur := string(objects) + "|" + string(scalars)
+
+		if i == 0 {
+			first = cur
+			continue
+		}
+		assert.Equalf(t, first, cur, "object/scalar type output must be deterministic (iteration %d differed)", i)
+	}
+}
+
+// TestSchemaCollision_NativeQueryCollision verifies that native queries
+// participate in the same global name resolution as regular indices.
+func TestSchemaCollision_NativeQueryCollision(t *testing.T) {
+	const cfgJSON = `{
+	  "indices": {
+	    "orders": {"mappings": {"properties": {
+	      "address": {"type": "nested", "properties": {
+	        "street":  {"type": "text"},
+	        "city":    {"type": "keyword"},
+	        "country": {"type": "keyword"}
+	      }}
+	    }}}
+	  },
+	  "queries": {
+	    "recent_orders": {
+	      "index": "orders",
+	      "query": {"match_all": {}},
+	      "return_type": {
+	        "kind": "defination",
+	        "mappings": {"properties": {
+	          "address": {"type": "nested", "properties": {
+	            "city":    {"type": "keyword"},
+	            "country": {"type": "keyword"}
+	          }}
+	        }}
+	      }
+	    }
+	  }
+	}`
+
+	cfg, st := collisionState(t, cfgJSON)
+	resp := connector.ParseConfigurationToSchema(cfg, st)
+
+	ordersAddrType := nestedTypeName(t, resp, "orders", "address")
+	nqAddrType := nestedTypeName(t, resp, "recent_orders", "address")
+
+	// The native query's address (2 fields) must not overwrite the index's
+	// address (3 fields).
+	assert.NotEqual(t, ordersAddrType, nqAddrType,
+		"native query address and index address have different shapes and must be separate types")
+
+	ordersFields := objectFieldNames(t, resp, ordersAddrType)
+	assert.True(t, ordersFields["street"], "orders.address must keep field 'street'")
+	assert.True(t, ordersFields["city"])
+	assert.True(t, ordersFields["country"])
+
+	// Collect all field names to check for no unexpected extras.
+	allNames := make([]string, 0)
+	for n := range ordersFields {
+		allNames = append(allNames, n)
+	}
+	sort.Strings(allNames)
+	assert.Equal(t, []string{"city", "country", "street"}, allNames)
+}

--- a/testdata/unit_tests/fields_tests/nested_multi/configuration.json
+++ b/testdata/unit_tests/fields_tests/nested_multi/configuration.json
@@ -1,0 +1,45 @@
+{
+  "indices": {
+    "orders": {
+      "mappings": {
+        "properties": {
+          "order_id": {
+            "type": "keyword"
+          },
+          "placed_at": {
+            "type": "date"
+          },
+          "address": {
+            "type": "nested",
+            "properties": {
+              "street": {
+                "type": "text"
+              },
+              "city": {
+                "type": "keyword"
+              },
+              "country": {
+                "type": "keyword"
+              }
+            }
+          },
+          "line_items": {
+            "type": "nested",
+            "properties": {
+              "sku": {
+                "type": "keyword"
+              },
+              "quantity": {
+                "type": "integer"
+              },
+              "price": {
+                "type": "float"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "queries": {}
+}

--- a/testdata/unit_tests/fields_tests/nested_multi/want_schema.json
+++ b/testdata/unit_tests/fields_tests/nested_multi/want_schema.json
@@ -1,0 +1,905 @@
+{
+  "collections": [
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "orders",
+      "type": "orders",
+      "uniqueness_constraints": {}
+    }
+  ],
+  "functions": [],
+  "object_types": {
+    "address": {
+      "fields": {
+        "city": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "country": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "street": {
+          "type": {
+            "name": "text",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "date_range_query": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "format": {
+          "description": "(Optional, string) Date format used to convert date values in the query.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "time_zone": {
+          "description": "(Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query to UTC.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "line_items": {
+      "fields": {
+        "price": {
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "quantity": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "sku": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "orders": {
+      "fields": {
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "address": {
+          "type": {
+            "element_type": {
+              "name": "address",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "line_items": {
+          "type": {
+            "element_type": {
+              "name": "line_items",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "order_id": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "placed_at": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "range": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "stats": {
+      "fields": {
+        "avg": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "string_stats": {
+      "fields": {
+        "avg_length": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "entropy": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "max_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      }
+    }
+  },
+  "procedures": [],
+  "scalar_types": {
+    "_id": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "_id",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "date": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "date_range_query",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "date",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "double": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "double",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float64"
+      }
+    },
+    "float": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "float",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float32"
+      }
+    },
+    "integer": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "integer",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int32"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "long": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "long",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int64"
+      }
+    },
+    "text": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase_prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "text",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `ParseConfigurationToSchema` keyed nested object types by bare field name, so identically-named nested objects across indices (or within a single index) overwrote each other in the global `ObjectTypes` map — last-write-wins, nondeterministic via Go map iteration order, silently dropping fields from the losing definition
- Replaces the single-pass emit with a **collect → resolve → emit** pipeline that guarantees no dropped fields and deterministic output
- Native queries participate in the same global name-resolution pass

## Root cause

In `getScalarTypesAndObjects`, every nested object was tagged with just its bare field name (e.g. `"address"`). `prepareNdcSchema` then wrote all objects to `ObjectTypes["address"]`, so any two indices with a nested `address` field would clobber each other. The same bug occurs within a single index when two nested objects each contain a child with the same field name but different structures.

## Fix

1. **Collect**: tag each nested object with a fully-qualified name (`index.path.to.field`) and a recursive structural signature
2. **Resolve** (`resolveObjectTypeNames`): keep the bare name when it maps to exactly one distinct structure and doesn't collide with a reserved name; otherwise use the fully-qualified name
3. **Emit**: rewrite field type references via the resolution map, then call `prepareNdcSchema`

## Backward compatibility

- No collisions (common case): fully non-breaking — bare names unchanged
- Identical index/alias duplicates: non-breaking, collapse to shared bare name
- Genuine collisions: breaking only for those types (already broken — nondeterministic, dropping fields). Migration: re-introspect + re-track

## Test plan

- [x] `TestSchemaCollision_CrossIndexDifferentShapes` — two indices with same-named nested object but different fields; verifies both retain all fields under distinct type names
- [x] `TestSchemaCollision_CrossIndexIdenticalShapes` — index + alias with identical nested object; verifies bare name is preserved (minimal churn)
- [x] `TestSchemaCollision_WithinIndex` — single index where two nested objects each contain a same-named child with different fields
- [x] `TestSchemaCollision_Deterministic` — 50-run byte-identical object/scalar output guard
- [x] `TestSchemaCollision_NativeQueryCollision` — native query objects join global resolution
- [x] `TestSchema/nested_multi` — new golden-file regression: single index with two distinct nested objects keeps bare names after fix
- [x] All existing `TestSchema`, `TestGetPredicate`, `TestPrepareElasticsearchQuery` tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)