### PR TITLE
test(e2e): enforce DDN↔ES result-set parity in L4 runQuery

### DIFF
--- a/e2e/harness/e2e_test.go
+++ b/e2e/harness/e2e_test.go
@@ -181,7 +181,9 @@ func runCase(t *testing.T, env *Env, c Case) {
 }
 
 // runQuery executes one L4 query: raw ES _search + DDN GraphQL, then either
-// (re)generates goldens or LLM-compares DDN-vs-ES and each-vs-its-golden.
+// (re)generates goldens or, in comparison mode, asserts DDN<->ES result-set
+// parity (the suite's stated purpose) and that each result matches its
+// committed golden.
 func runQuery(ctx context.Context, t *testing.T, env *Env, stack *Stack, es *ESClient, c Case, q Query) QueryReport {
 	qStart := time.Now()
 	qr := QueryReport{Name: q.Name, Layer: "L4", Target: q.Target.Index}
@@ -262,6 +264,20 @@ func runQuery(ctx context.Context, t *testing.T, env *Env, stack *Stack, es *ESC
 		t.Logf("[%s/%s] golden.es.json is pending; skipping comparison (run UPDATE_GOLDEN=1)", c.Name, q.Name)
 	case !jsonEqual(esBody, goldenES):
 		failMsgs = append(failMsgs, "ES result does not match golden.es.json")
+	}
+
+	// Core purpose of the suite: the DDN/GraphQL result set must equal the
+	// result set of the equivalent raw ES query, after normalizing the known,
+	// expected representation differences (envelope shape, field-name casing,
+	// object-as-array nesting; order-sensitive iff the query pins an ordering).
+	// This assertion runs on the live results independently of the goldens, so a
+	// real divergence baked into both goldens (they are regenerated together
+	// under UPDATE_GOLDEN=1) is still caught. Aggregation-shaped results are not
+	// amenable to row parity and are skipped.
+	if skipped, mismatch := compareDDNvsES(ddnData, esBody, queryIsOrdered(q)); skipped {
+		t.Logf("[%s/%s] DDN<->ES row-parity skipped (aggregation-shaped result)", c.Name, q.Name)
+	} else if mismatch != "" {
+		failMsgs = append(failMsgs, mismatch)
 	}
 
 	if len(failMsgs) == 0 {

--- a/e2e/harness/parity.go
+++ b/e2e/harness/parity.go
@@ -1,0 +1,233 @@
+//go:build e2e
+
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file implements the DDN<->ES result-set parity check that enforces the
+// suite's stated purpose: "GraphQL queries return the same result set as the
+// equivalent query sent directly to Elasticsearch."
+//
+// A naive deep-equal of the raw DDN and ES JSON produces false failures because
+// the two sides represent the same data differently in known, expected ways.
+// compareDDNvsES normalizes those differences before comparing:
+//
+//   - Envelope shape: DDN returns rows under the model field
+//     ({"<model>": [ ...rows... ]}); ES returns them under hits.hits[]._source.
+//     extractDDNRows / extractESRows pull the ordered row list from each side.
+//   - Field-name casing: DDN/GraphQL normalizes ES field names to camelCase
+//     (ES in_stock -> DDN inStock); canonicalizeRow folds keys on both sides to
+//     a canonical snake_case form recursively.
+//   - Object nesting: the connector models every ES object container (explicit
+//     object, nested, and implicit-object properties) as an ARRAY of a named
+//     object type, so a raw ES value {"dest":"US"} appears as [{"dest":"US"}]
+//     on the DDN side. canonicalizeRow unwraps single-element object arrays
+//     recursively so the two sides line up.
+//   - Ordering: rowSetsEqual is position-sensitive when the query pins an
+//     ordering (see queryIsOrdered) and an order-insensitive multiset
+//     comparison otherwise.
+//
+// Aggregation queries are shaped completely differently on the two sides
+// (DDN {"<model>Aggregate": {...}} vs ES {"aggregations": {...}}), so a
+// row-parity check cannot apply; compareDDNvsES detects and skips them.
+
+// compareDDNvsES enforces DDN<->ES result-set parity. It returns skipped=true
+// for aggregation-shaped results (which row parity cannot describe), and
+// otherwise returns a non-empty mismatch string describing the first divergence
+// found (empty when the result sets match). ordered selects position-sensitive
+// vs. order-insensitive row comparison.
+func compareDDNvsES(ddnData, esBody []byte, ordered bool) (skipped bool, mismatch string) {
+	if isAggregationResult(ddnData, esBody) {
+		return true, ""
+	}
+	ddnRows, ok := extractDDNRows(ddnData)
+	if !ok {
+		return false, "could not extract DDN row list from result envelope"
+	}
+	esRows, ok := extractESRows(esBody)
+	if !ok {
+		return false, "could not extract ES row list from hits.hits[]._source"
+	}
+	if equal, detail := rowSetsEqual(ddnRows, esRows, ordered); !equal {
+		return false, "DDN result set diverges from equivalent ES result set: " + detail
+	}
+	return false, ""
+}
+
+// queryIsOrdered reports whether the query pins a result ordering — a GraphQL
+// order_by argument or an ES sort clause. When it does, the DDN<->ES comparison
+// is position-sensitive; otherwise an order-insensitive comparison is used.
+func queryIsOrdered(q Query) bool {
+	if strings.Contains(q.GraphQL, "order_by") {
+		return true
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(q.ESSearch, &body); err == nil {
+		if _, ok := body["sort"]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// extractDDNRows returns the ordered row list from a DDN GraphQL data payload of
+// shape {"<model>": [ ...rows... ]}. ok is false when the payload is not
+// row-shaped (e.g. an aggregation {"<model>Aggregate": {...}}). Keys are visited
+// in sorted order so selection is deterministic if more than one root field is
+// present.
+func extractDDNRows(ddnData []byte) ([]interface{}, bool) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(ddnData, &top); err != nil {
+		return nil, false
+	}
+	keys := make([]string, 0, len(top))
+	for k := range top {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		var arr []interface{}
+		if err := json.Unmarshal(top[k], &arr); err == nil {
+			return arr, true
+		}
+	}
+	return nil, false
+}
+
+// extractESRows returns the ordered list of _source objects from a raw ES
+// _search response (hits.hits[]._source). ok is false when the body is not a
+// hits-shaped search response.
+func extractESRows(esBody []byte) ([]interface{}, bool) {
+	var top struct {
+		Hits struct {
+			Hits []struct {
+				Source interface{} `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(esBody, &top); err != nil {
+		return nil, false
+	}
+	// Distinguish "no hits envelope at all" from "zero hits": require the key.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(esBody, &probe); err != nil {
+		return nil, false
+	}
+	if _, ok := probe["hits"]; !ok {
+		return nil, false
+	}
+	rows := make([]interface{}, 0, len(top.Hits.Hits))
+	for _, h := range top.Hits.Hits {
+		rows = append(rows, h.Source)
+	}
+	return rows, true
+}
+
+// isAggregationResult reports whether the paired results are aggregation-shaped
+// (and thus not amenable to a row-parity comparison): a non-empty ES
+// "aggregations" object, or a DDN payload with no array-valued root field.
+func isAggregationResult(ddnData, esBody []byte) bool {
+	var esTop map[string]json.RawMessage
+	if json.Unmarshal(esBody, &esTop) == nil {
+		if aggs, ok := esTop["aggregations"]; ok {
+			var m map[string]interface{}
+			if json.Unmarshal(aggs, &m) == nil && len(m) > 0 {
+				return true
+			}
+		}
+	}
+	if _, ok := extractDDNRows(ddnData); !ok {
+		return true
+	}
+	return false
+}
+
+// rowSetsEqual compares two row lists after canonicalizing each row. When
+// ordered is true the comparison is position-sensitive; otherwise it is an
+// order-insensitive multiset comparison. detail describes the first divergence.
+func rowSetsEqual(ddnRows, esRows []interface{}, ordered bool) (equal bool, detail string) {
+	if len(ddnRows) != len(esRows) {
+		return false, fmt.Sprintf("row count differs: DDN=%d ES=%d", len(ddnRows), len(esRows))
+	}
+	ddnCanon := make([]string, len(ddnRows))
+	esCanon := make([]string, len(esRows))
+	for i := range ddnRows {
+		ddnCanon[i] = canonicalJSON(ddnRows[i])
+	}
+	for i := range esRows {
+		esCanon[i] = canonicalJSON(esRows[i])
+	}
+	if !ordered {
+		sort.Strings(ddnCanon)
+		sort.Strings(esCanon)
+	}
+	for i := range ddnCanon {
+		if ddnCanon[i] != esCanon[i] {
+			return false, fmt.Sprintf("row %d differs:\n  DDN: %s\n   ES: %s", i, ddnCanon[i], esCanon[i])
+		}
+	}
+	return true, ""
+}
+
+// canonicalJSON canonicalizes a decoded JSON value and marshals it to a string.
+// json.Marshal sorts map keys, so the output is a stable canonical form usable
+// for equality and sorting.
+func canonicalJSON(v interface{}) string {
+	b, err := json.Marshal(canonicalizeRow(v))
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return string(b)
+}
+
+// canonicalizeRow recursively normalizes a decoded JSON value so DDN and ES
+// representations of the same data compare equal: map keys are folded to
+// snake_case, and single-element arrays whose sole element is an object are
+// unwrapped to that object (the connector's object-as-array modeling).
+func canonicalizeRow(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(t))
+		for k, val := range t {
+			out[toSnakeCase(k)] = canonicalizeRow(val)
+		}
+		return out
+	case []interface{}:
+		arr := make([]interface{}, len(t))
+		for i, e := range t {
+			arr[i] = canonicalizeRow(e)
+		}
+		if len(arr) == 1 {
+			if _, ok := arr[0].(map[string]interface{}); ok {
+				return arr[0]
+			}
+		}
+		return arr
+	default:
+		return v
+	}
+}
+
+// toSnakeCase folds a camelCase / PascalCase identifier to snake_case. It is
+// idempotent for identifiers that are already snake_case or lower-case, so
+// applying it to both the DDN (camelCase) and ES (snake_case) sides yields a
+// common canonical form.
+func toSnakeCase(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r - 'A' + 'a')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/e2e/harness/parity_test.go
+++ b/e2e/harness/parity_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+package harness
+
+import "testing"
+
+// TestCompareDDNvsES exercises the DDN<->ES result-set parity assertion directly
+// with hand-constructed payloads. The ES payloads use the real _search envelope
+// ({"hits":{"hits":[{"_source":{...}}]}}) and the DDN payloads use the real
+// GraphQL data envelope ({"<model>": [ ...rows... ]}).
+//
+// The cases prove three things:
+//   - NEGATIVE: the assertion CATCHES genuine divergence (row count, field
+//     value, and order for ordered queries).
+//   - POSITIVE: it does NOT false-fail on the known, expected representation
+//     differences (field-name casing, object-as-array nesting, and row order
+//     for unordered queries).
+//   - SKIP: aggregation-shaped pairs are skipped (row parity does not apply).
+func TestCompareDDNvsES(t *testing.T) {
+	tests := []struct {
+		name         string
+		ddn          string
+		es           string
+		ordered      bool
+		wantSkipped  bool
+		wantMismatch bool // true => expect a non-empty mismatch string
+	}{
+		// ---- NEGATIVE: assertion must catch divergence ----
+		{
+			name: "neg/row_missing_in_ddn",
+			// ES has two rows, DDN only one -> row count differs.
+			ddn:          `{"products":[{"sku":"PRD-001"}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-001"}},{"_source":{"sku":"PRD-002"}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: true,
+		},
+		{
+			name: "neg/row_missing_in_es",
+			// DDN has two rows, ES only one -> row count differs.
+			ddn:          `{"products":[{"sku":"PRD-001"},{"sku":"PRD-002"}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-001"}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: true,
+		},
+		{
+			name: "neg/field_value_differs",
+			// Same row count but the inStock/in_stock value disagrees.
+			ddn:          `{"products":[{"sku":"PRD-001","inStock":false}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-001","in_stock":true}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: true,
+		},
+		{
+			name: "neg/ordered_same_rows_different_order",
+			// Identical rows, different order, ordered query -> position-sensitive fail.
+			ddn:          `{"products":[{"sku":"PRD-001"},{"sku":"PRD-002"}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-002"}},{"_source":{"sku":"PRD-001"}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: true,
+		},
+
+		// ---- POSITIVE: must not false-fail on expected representation diffs ----
+		{
+			name: "pos/field_name_casing",
+			// ES snake_case vs DDN camelCase, same data -> equal.
+			ddn:          `{"products":[{"sku":"PRD-001","inStock":true}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-001","in_stock":true}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: false,
+		},
+		{
+			name: "pos/object_as_array_nesting",
+			// ES object {"dest":"US"} vs DDN single-element object array [{"dest":"US"}] -> equal after unwrap.
+			ddn:          `{"kibanaSampleDataLogs":[{"geo":[{"dest":"US"}]}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"geo":{"dest":"US"}}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: false,
+		},
+		{
+			name: "pos/unordered_same_rows_different_order",
+			// Same rows, different order, unordered query -> order-insensitive equal.
+			ddn:          `{"products":[{"sku":"PRD-001"},{"sku":"PRD-002"}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-002"}},{"_source":{"sku":"PRD-001"}}]}}`,
+			ordered:      false,
+			wantSkipped:  false,
+			wantMismatch: false,
+		},
+		{
+			name: "pos/casing_and_nesting_combined",
+			// Both representation diffs at once, same data -> equal.
+			ddn:          `{"products":[{"sku":"PRD-001","shipInfo":[{"toCountry":"US"}]}]}`,
+			es:           `{"hits":{"hits":[{"_source":{"sku":"PRD-001","ship_info":{"to_country":"US"}}}]}}`,
+			ordered:      true,
+			wantSkipped:  false,
+			wantMismatch: false,
+		},
+
+		// ---- SKIP: aggregation-shaped pair ----
+		{
+			name: "skip/aggregation",
+			// ES aggregations object + DDN <model>Aggregate object (no array root) -> skipped.
+			ddn:          `{"kibanaSampleDataLogsAggregate":{"bytes":{"avg":5664.75}}}`,
+			es:           `{"aggregations":{"avg_bytes":{"value":5664.75}},"hits":{"hits":[]}}`,
+			ordered:      false,
+			wantSkipped:  true,
+			wantMismatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			skipped, mismatch := compareDDNvsES([]byte(tt.ddn), []byte(tt.es), tt.ordered)
+			if skipped != tt.wantSkipped {
+				t.Fatalf("skipped = %v, want %v (mismatch=%q)", skipped, tt.wantSkipped, mismatch)
+			}
+			if got := mismatch != ""; got != tt.wantMismatch {
+				t.Fatalf("mismatch present = %v, want %v (mismatch=%q)", got, tt.wantMismatch, mismatch)
+			}
+			if tt.wantMismatch {
+				t.Logf("correctly caught divergence: %s", mismatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The gap

The e2e suite's stated purpose is:

> GraphQL queries return the same result set as the equivalent query sent directly to Elasticsearch.

But **no assertion enforced it.** `runQuery` only checked two things, independently:

- `DDN == golden.ddn.json`
- `ES == golden.es.json`

It never compared DDN against ES. And because both goldens are regenerated **together** under `UPDATE_GOLDEN=1`, a real DDN-vs-ES divergence gets baked into *both* goldens and the suite stays green. The one property the suite exists to guarantee was unguarded.

On top of that, the `runQuery` doc comment claimed it *"LLM-compares DDN-vs-ES and each-vs-its-golden"* — there was no DDN-vs-ES comparison and no LLM comparison anywhere in the harness.

## The change

### 1. New DDN↔ES row-parity assertion (`e2e/harness/parity.go`)

Added `compareDDNvsES`, wired into `runQuery` **on top of** the existing golden assertions (goldens are unchanged). It runs on the **live** DDN and ES results, independently of the golden files — so a divergence baked into both goldens is still caught.

A naive deep-equal of raw DDN vs raw ES would false-fail, because the two sides represent the same data differently in known, expected (non-bug) ways. The comparison normalizes these first:

- **Envelope shape** — DDN returns rows under the model field (`{"<model>": [ …rows… ]}`); ES returns them under `hits.hits[]._source`. `extractDDNRows` / `extractESRows` pull the ordered row list from each side.
- **Field-name casing** — DDN/GraphQL normalizes ES field names to camelCase (`in_stock` → `inStock`); the raw ES `_source` stays snake_case. Keys on both sides are folded to a canonical snake_case form, recursively.
- **Object-as-array nesting** — the connector models every ES object container (explicit `object`, `nested`, and implicit-object properties) as an **array** of a named object type, so a raw ES `{"dest":"US"}` appears as `[{"dest":"US"}]` on the DDN side. Single-element object arrays are unwrapped recursively so the two sides line up. (Scalar arrays like `tags: ["metal","rubber"]` are left intact.)
- **Ordering** — the comparison is **position-sensitive** when the query pins an ordering (a GraphQL `order_by` or an ES `sort`) and an order-insensitive multiset comparison otherwise.

**Aggregations** (`{"<model>Aggregate": { … }}` on DDN vs `{"aggregations": { … }}` on ES) are shaped too differently for a row-parity check, so they are detected and **skipped** — they do not false-fail the new assertion.

Verified locally: the assertion passes on all 17 committed golden pairs, correctly skips the aggregation case, and correctly *fails* on injected DDN↔ES divergences and on order violations for ordered queries.

### 2. Removed the misleading `runQuery` comment

Replaced the inaccurate "LLM-compares DDN-vs-ES and each-vs-its-golden" comment with one that describes what the function actually does.

## Follow-ups (intentionally out of scope)

Finer-grained tie-breakers for unordered comparisons (e.g. when rows are only distinguishable by fields not selected) and fixture improvements are left as follow-ups.

## Notes

- Base branch is `feat/e2e-test-suite` (PR #128), so this diff is stacked on top of the e2e suite.
- The parity logic lives behind the `e2e` build tag, so it does not affect the normal `go build ./...` / `make unit-test` CI jobs (both pass locally).
- Originating PromptQL thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/c2f45c8e-ee70-4db8-b7ab-4770968630bf

🤖 Generated with [Claude Code](https://claude.com/claude-code)