### PR TITLE
feat(e2e): snapshot connector /schema as a golden per case

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -48,13 +48,15 @@ Per case, the harness ([`harness/`](harness/)) runs these stages:
 3. **Introspect** — run the connector's real `ndc-elasticsearch update` (a
    one-shot container) to generate `configuration.json` from the live ES.
 4. **Connector up** — start the connector (`serve`) with that configuration.
-5. **L3 assertions** — schema conformance (see [below](#assertions-in-detail)).
-6. **DDN build** — drive the real `ddn` CLI:
+5. **Schema golden** — snapshot the connector's full `GET /schema` and compare it
+   against the committed `golden.schema.json` (see [below](#assertions-in-detail)).
+6. **L3 assertions** — schema conformance (see [below](#assertions-in-detail)).
+7. **DDN build** — drive the real `ddn` CLI:
    `supergraph init` → `connector-link add` → `connector-link update`
    (introspect) → `model add "*"` → `supergraph build local`. Metadata is
    **never hand-edited**, so every index automatically becomes a GraphQL model.
-7. **Engine up** — start the DDN v3-engine + dev auth webhook on the built metadata.
-8. **L4 assertions** — for each query: POST GraphQL to the engine and the
+8. **Engine up** — start the DDN v3-engine + dev auth webhook on the built metadata.
+9. **L4 assertions** — for each query: POST GraphQL to the engine and the
    equivalent DSL to ES, then compare both results against their committed golden
    files (see [below](#assertions-in-detail)).
 
@@ -70,7 +72,7 @@ e2e/
   harness/                    the ONLY code — never edited to add a case
     e2e_test.go               discovery + per-case orchestration + L3/L4 + report
     config.go  discover.go  stack.go  seed.go  es.go  ddn.go
-    schema_assert.go  typemap.go  graphql.go  report.go  exec.go  doc.go
+    schema_assert.go  schema_golden.go  typemap.go  graphql.go  report.go  exec.go  doc.go
   cases/
     kibana_sample_logs/       reference case using the elastic.co "logs" sample dataset
     custom_products/          fully-custom example (indices/ + data/ + init/ + queries/)
@@ -253,7 +255,25 @@ A golden may be the sentinel `{"__pending__": true}`; its comparison is
 **skipped** (both queries still run and their payloads are recorded in the report)
 until you regenerate it.
 
+Per-case files (alongside `indices/`, `queries/`, …):
+
+| File | Required | Purpose |
+|---|---|---|
+| `golden.schema.json` | committed | snapshot of the connector's full `GET /schema` for the case (regenerate with `UPDATE_GOLDEN=1`); the same `{"__pending__": true}` sentinel skips its comparison |
+
 ## Assertions in detail
+
+**Schema golden** (per case): snapshot the connector's entire `GET /schema`
+document and compare it against the committed `golden.schema.json`. Unlike L3
+(which checks *conformance* to the live ES mapping and is invariant under
+object-type renames), this is a **snapshot** of the generated NDC schema surface,
+so any change to it — an object-type rename, a new/dropped type, a changed field
+type — surfaces as a reviewable golden diff instead of passing silently. Because
+the connector emits `collections`/`functions`/`procedures` in nondeterministic
+Go-map order, the snapshot is canonicalised (those arrays sorted by name; all
+object keys are already sorted by the JSON encoder) before writing/comparing, so
+the golden is stable. Regenerate with `UPDATE_GOLDEN=1` after an intended schema
+change, then review and commit the diff.
 
 **L3 — schema conformance** (per seeded index):
 

--- a/e2e/cases/custom_products/golden.schema.json
+++ b/e2e/cases/custom_products/golden.schema.json
@@ -1,0 +1,1194 @@
+{
+  "collections": [
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "products",
+      "type": "products",
+      "uniqueness_constraints": {}
+    },
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "products_alias",
+      "type": "products_alias",
+      "uniqueness_constraints": {}
+    }
+  ],
+  "functions": [],
+  "object_types": {
+    "date_range_query": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "format": {
+          "description": "(Optional, string) Date format used to convert date values in the query.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "time_zone": {
+          "description": "(Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query to UTC.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "manufacturer": {
+      "fields": {
+        "country": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "name": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "products": {
+      "fields": {
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "created_at": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        },
+        "description": {
+          "type": {
+            "name": "text",
+            "type": "named"
+          }
+        },
+        "in_stock": {
+          "type": {
+            "name": "boolean",
+            "type": "named"
+          }
+        },
+        "location": {
+          "type": {
+            "name": "geo_point",
+            "type": "named"
+          }
+        },
+        "manufacturer": {
+          "type": {
+            "element_type": {
+              "name": "manufacturer",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "name": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "price": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "quantity": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "rating": {
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "sku": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "tags": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "products_alias": {
+      "fields": {
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "created_at": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        },
+        "description": {
+          "type": {
+            "name": "text",
+            "type": "named"
+          }
+        },
+        "in_stock": {
+          "type": {
+            "name": "boolean",
+            "type": "named"
+          }
+        },
+        "location": {
+          "type": {
+            "name": "geo_point",
+            "type": "named"
+          }
+        },
+        "manufacturer": {
+          "type": {
+            "element_type": {
+              "name": "manufacturer",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "name": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "price": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "quantity": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "rating": {
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "sku": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "tags": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "range": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "stats": {
+      "fields": {
+        "avg": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "string_stats": {
+      "fields": {
+        "avg_length": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "entropy": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "max_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      }
+    }
+  },
+  "procedures": [],
+  "scalar_types": {
+    "_id": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "_id",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "boolean": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "boolean",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "boolean",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "boolean",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "boolean"
+      }
+    },
+    "date": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "date_range_query",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "date",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "double": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "double",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float64"
+      }
+    },
+    "float": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "float",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float32"
+      }
+    },
+    "geo_point": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "integer": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "integer",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int32"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "long": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "long",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int64"
+      }
+    },
+    "text": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase_prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "text",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "text",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "text.keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/e2e/cases/kibana_sample_logs/golden.schema.json
+++ b/e2e/cases/kibana_sample_logs/golden.schema.json
@@ -1,0 +1,1139 @@
+{
+  "collections": [
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "kibana_sample_data_logs",
+      "type": "kibana_sample_data_logs",
+      "uniqueness_constraints": {}
+    }
+  ],
+  "functions": [],
+  "object_types": {
+    "date_range_query": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "format": {
+          "description": "(Optional, string) Date format used to convert date values in the query.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "time_zone": {
+          "description": "(Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query to UTC.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "event": {
+      "fields": {
+        "dataset": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "geo": {
+      "fields": {
+        "coordinates": {
+          "type": {
+            "name": "geo_point",
+            "type": "named"
+          }
+        },
+        "dest": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "src": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "srcdest": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "kibana_sample_data_logs": {
+      "fields": {
+        "@timestamp": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        },
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "agent": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "bytes": {
+          "type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "bytes_counter": {
+          "type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "bytes_gauge": {
+          "type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "clientip": {
+          "type": {
+            "name": "ip",
+            "type": "named"
+          }
+        },
+        "event": {
+          "type": {
+            "element_type": {
+              "name": "event",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "extension": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "geo": {
+          "type": {
+            "element_type": {
+              "name": "geo",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "host": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "index": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "ip": {
+          "type": {
+            "name": "ip",
+            "type": "named"
+          }
+        },
+        "ip_range": {
+          "type": {
+            "name": "ip_range",
+            "type": "named"
+          }
+        },
+        "machine": {
+          "type": {
+            "element_type": {
+              "name": "machine",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "memory": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "message": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "phpmemory": {
+          "type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "referer": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "request": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "response": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "tags": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "timestamp": {
+          "type": {
+            "name": "alias",
+            "type": "named"
+          }
+        },
+        "timestamp_range": {
+          "type": {
+            "name": "date_range",
+            "type": "named"
+          }
+        },
+        "url": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "utc_time": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "machine": {
+      "fields": {
+        "os": {
+          "type": {
+            "name": "text.keyword",
+            "type": "named"
+          }
+        },
+        "ram": {
+          "type": {
+            "name": "long",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "range": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "stats": {
+      "fields": {
+        "avg": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "string_stats": {
+      "fields": {
+        "avg_length": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "entropy": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "max_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      }
+    }
+  },
+  "procedures": [],
+  "scalar_types": {
+    "_id": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "_id",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "alias": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "date": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "date_range_query",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "date",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "date_range": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "double": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "double",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float64"
+      }
+    },
+    "float": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "float",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float32"
+      }
+    },
+    "geo_point": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "integer": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "integer",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int32"
+      }
+    },
+    "ip": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "ip",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "ip",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "ip",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "ip_range": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "long": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "long",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int64"
+      }
+    },
+    "text.keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/e2e/harness/discover.go
+++ b/e2e/harness/discover.go
@@ -23,6 +23,9 @@ type Case struct {
 
 	Meta    CaseMeta // parsed case.yaml (zero value if absent)
 	Queries []Query  // discovered under queries/
+
+	// GoldenSchemaPath is the committed golden.schema.json snapshot of /schema.
+	GoldenSchemaPath string
 }
 
 // CaseMeta is the parsed case.yaml.
@@ -92,7 +95,11 @@ func DiscoverCases(env *Env) ([]Case, error) {
 }
 
 func loadCase(dir string) (*Case, error) {
-	c := &Case{Name: filepath.Base(dir), Dir: dir}
+	c := &Case{
+		Name:             filepath.Base(dir),
+		Dir:              dir,
+		GoldenSchemaPath: filepath.Join(dir, "golden.schema.json"),
+	}
 
 	var err error
 	if c.IndexMappings, err = globSorted(dir, "indices", "*.mapping.json"); err != nil {

--- a/e2e/harness/e2e_test.go
+++ b/e2e/harness/e2e_test.go
@@ -135,6 +135,28 @@ func runCase(t *testing.T, env *Env, c Case) {
 		return
 	}
 
+	// ---- schema golden: full connector /schema snapshot ----
+	t.Run("schema-golden", func(t *testing.T) {
+		res, err := AssertSchemaGolden(ctx, env, stack, c)
+		cr.SchemaGoldenStatus = res.Status
+		cr.SchemaGoldenMessage = res.Message
+		if err != nil {
+			cr.SchemaGoldenStatus = StatusFail
+			cr.SchemaGoldenMessage = "assertion error: " + err.Error()
+			cr.Status = StatusFail
+			t.Fatalf("[%s] schema golden error: %v", c.Name, err)
+		}
+		switch res.Status {
+		case StatusFail:
+			cr.SchemaGoldenActual = res.Actual
+			cr.SchemaGoldenExpected = res.Expected
+			cr.Status = StatusFail
+			t.Errorf("[%s] schema golden: %s", c.Name, res.Message)
+		case StatusSkip:
+			t.Skipf("[%s] %s", c.Name, res.Message)
+		}
+	})
+
 	// ---- L3: schema conformance ----
 	t.Run("L3-schema", func(t *testing.T) {
 		problems, err := AssertSchemaConformance(ctx, stack, es)
@@ -317,17 +339,6 @@ func requireCmd(t *testing.T, name string) {
 	if !commandExists(name) {
 		t.Fatalf("required command %q not found on PATH", name)
 	}
-}
-
-// isPendingGolden reports whether a golden file is the pending-regeneration
-// sentinel {"__pending__": true}.
-func isPendingGolden(b []byte) bool {
-	var m map[string]interface{}
-	if err := json.Unmarshal(b, &m); err != nil {
-		return false
-	}
-	v, ok := m["__pending__"].(bool)
-	return ok && v
 }
 
 func pretty(b []byte) string {

--- a/e2e/harness/report.go
+++ b/e2e/harness/report.go
@@ -42,15 +42,22 @@ type QueryReport struct {
 
 // CaseReport is the outcome for a whole case (L3 + all its L4 queries).
 type CaseReport struct {
-	Name           string        `json:"name"`
-	Status         string        `json:"status"`
-	Message        string        `json:"message,omitempty"`
-	SchemaLayer    string        `json:"schema_layer"` // "L3"
-	SchemaStatus   string        `json:"schema_status"`
-	SchemaProblems []string      `json:"schema_problems,omitempty"`
-	Queries        []QueryReport `json:"queries"`
-	Timings        []StepTiming  `json:"timings,omitempty"`
-	DurationMS     int64         `json:"duration_ms"`
+	Name           string   `json:"name"`
+	Status         string   `json:"status"`
+	Message        string   `json:"message,omitempty"`
+	SchemaLayer    string   `json:"schema_layer"` // "L3"
+	SchemaStatus   string   `json:"schema_status"`
+	SchemaProblems []string `json:"schema_problems,omitempty"`
+
+	// Schema golden: whole-schema snapshot comparison (golden.schema.json).
+	SchemaGoldenStatus   string `json:"schema_golden_status,omitempty"`
+	SchemaGoldenMessage  string `json:"schema_golden_message,omitempty"`
+	SchemaGoldenActual   string `json:"schema_golden_actual,omitempty"`   // attached on failure
+	SchemaGoldenExpected string `json:"schema_golden_expected,omitempty"` // attached on failure
+
+	Queries    []QueryReport `json:"queries"`
+	Timings    []StepTiming  `json:"timings,omitempty"`
+	DurationMS int64         `json:"duration_ms"`
 }
 
 // Report is the top-level e2e report.
@@ -150,6 +157,17 @@ func (r *Report) markdown() string {
 				b.WriteString("- " + escapeMD(p) + "\n")
 			}
 			b.WriteString("\n</details>\n\n")
+		}
+
+		if c.SchemaGoldenStatus != "" {
+			b.WriteString(fmt.Sprintf("**Schema golden:** %s %s\n\n", statusEmoji(c.SchemaGoldenStatus), c.SchemaGoldenStatus))
+			if c.SchemaGoldenStatus == StatusFail {
+				if c.SchemaGoldenMessage != "" {
+					b.WriteString("> " + escapeMD(c.SchemaGoldenMessage) + "\n\n")
+				}
+				writeDetails(&b, "connector /schema (actual)", c.SchemaGoldenActual)
+				writeDetails(&b, "golden.schema.json (expected)", c.SchemaGoldenExpected)
+			}
 		}
 
 		b.WriteString("| query | layer | target | status |\n")

--- a/e2e/harness/schema_golden.go
+++ b/e2e/harness/schema_golden.go
@@ -1,0 +1,146 @@
+//go:build e2e
+
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+)
+
+// schemaGoldenResult is the outcome of the case-level schema-golden step.
+type schemaGoldenResult struct {
+	Status   string // StatusPass | StatusFail | StatusSkip
+	Message  string
+	Actual   string // canonicalized connector /schema (attached on failure)
+	Expected string // canonicalized golden.schema.json (attached on failure)
+}
+
+// FetchConnectorSchemaRaw GETs the connector's full /schema body (unlike
+// FetchConnectorSchema, which decodes only a minimal projection for L3).
+func FetchConnectorSchemaRaw(ctx context.Context, connectorPort int) ([]byte, error) {
+	url := fmt.Sprintf("http://localhost:%d/schema", connectorPort)
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s => %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// canonicalizeSchema returns a stable, pretty-printed /schema. The connector
+// emits collections/functions/procedures in nondeterministic Go-map order, so
+// sort those arrays by name (object keys are already sorted by the encoder) to
+// keep the golden stable across runs.
+func canonicalizeSchema(raw []byte) ([]byte, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parsing schema JSON: %w", err)
+	}
+	for _, key := range []string{"collections", "functions", "procedures"} {
+		arr, ok := doc[key].([]interface{})
+		if !ok {
+			continue
+		}
+		sort.SliceStable(arr, func(i, j int) bool {
+			return jsonObjectName(arr[i]) < jsonObjectName(arr[j])
+		})
+	}
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// isPendingGolden reports whether a golden file is the pending-regeneration
+// sentinel {"__pending__": true}. Shared by the query goldens (e2e_test.go) and
+// the schema golden below.
+func isPendingGolden(b []byte) bool {
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return false
+	}
+	v, ok := m["__pending__"].(bool)
+	return ok && v
+}
+
+// jsonObjectName extracts the "name" field of a decoded JSON object, or "" if
+// absent / not an object.
+func jsonObjectName(v interface{}) string {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := m["name"].(string)
+	return name
+}
+
+// AssertSchemaGolden snapshots the connector's full /schema and either
+// regenerates golden.schema.json (UPDATE_GOLDEN=1) or compares against it, so a
+// change to the generated schema surface shows up as a diff rather than
+// passing silently.
+func AssertSchemaGolden(ctx context.Context, env *Env, s *Stack, c Case) (schemaGoldenResult, error) {
+	raw, err := FetchConnectorSchemaRaw(ctx, s.Ports["connector"])
+	if err != nil {
+		return schemaGoldenResult{}, err
+	}
+	canonical, err := canonicalizeSchema(raw)
+	if err != nil {
+		return schemaGoldenResult{}, err
+	}
+	res := schemaGoldenResult{Actual: string(canonical)}
+
+	// Regeneration mode: write the golden and pass.
+	if env.UpdateGolden {
+		if err := os.WriteFile(c.GoldenSchemaPath, append(canonical, '\n'), 0o644); err != nil {
+			return res, fmt.Errorf("writing golden.schema.json: %w", err)
+		}
+		res.Status = StatusPass
+		res.Message = "schema golden regenerated (UPDATE_GOLDEN=1)"
+		return res, nil
+	}
+
+	// Comparison mode.
+	golden, _ := os.ReadFile(c.GoldenSchemaPath)
+	switch {
+	case len(golden) == 0:
+		res.Status = StatusFail
+		res.Message = "golden.schema.json missing; run with UPDATE_GOLDEN=1"
+		res.Expected = string(golden)
+		return res, nil
+	case isPendingGolden(golden):
+		res.Status = StatusSkip
+		res.Message = "golden.schema.json is pending; run UPDATE_GOLDEN=1 to capture it"
+		return res, nil
+	}
+
+	// Re-canonicalize the golden so formatting/order differences don't mismatch.
+	goldenCanonical, err := canonicalizeSchema(golden)
+	if err != nil {
+		res.Status = StatusFail
+		res.Message = "golden.schema.json is not valid JSON: " + err.Error()
+		res.Expected = string(golden)
+		return res, nil
+	}
+	res.Expected = string(goldenCanonical)
+
+	if !bytes.Equal(canonical, goldenCanonical) {
+		res.Status = StatusFail
+		res.Message = "connector /schema does not match golden.schema.json (run UPDATE_GOLDEN=1 to review/update)"
+		return res, nil
+	}
+	res.Status = StatusPass
+	return res, nil
+}

--- a/e2e/harness/schema_golden_test.go
+++ b/e2e/harness/schema_golden_test.go
@@ -1,0 +1,77 @@
+//go:build e2e
+
+package harness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two schema docs differing only in collection/object-type order must
+// canonicalize to identical bytes (the connector emits them in nondeterministic
+// Go-map order).
+func TestCanonicalizeSchema_DeterministicAcrossOrder(t *testing.T) {
+	a := []byte(`{
+		"collections": [{"name":"b","type":"b"},{"name":"a","type":"a"}],
+		"object_types": {"z":{"fields":{}},"a":{"fields":{}}},
+		"scalar_types": {},
+		"functions": [],
+		"procedures": []
+	}`)
+	b := []byte(`{
+		"collections": [{"name":"a","type":"a"},{"name":"b","type":"b"}],
+		"object_types": {"a":{"fields":{}},"z":{"fields":{}}},
+		"scalar_types": {},
+		"functions": [],
+		"procedures": []
+	}`)
+
+	ca, err := canonicalizeSchema(a)
+	require.NoError(t, err)
+	cb, err := canonicalizeSchema(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(ca), string(cb),
+		"canonical schema must be independent of collection / object-type ordering")
+
+	// collections must be sorted by name.
+	var doc map[string]interface{}
+	require.NoError(t, json.Unmarshal(ca, &doc))
+	cols := doc["collections"].([]interface{})
+	require.Len(t, cols, 2)
+	assert.Equal(t, "a", cols[0].(map[string]interface{})["name"])
+	assert.Equal(t, "b", cols[1].(map[string]interface{})["name"])
+}
+
+// Canonicalizing the same input repeatedly must yield identical bytes.
+func TestCanonicalizeSchema_StableAcrossRepeatedMarshal(t *testing.T) {
+	in := []byte(`{
+		"collections": [{"name":"c"},{"name":"a"},{"name":"b"}],
+		"object_types": {"products.manufacturer":{"fields":{"name":{"type":{"type":"named","name":"keyword"}}}}},
+		"scalar_types": {"keyword":{}},
+		"functions": [],
+		"procedures": []
+	}`)
+	first, err := canonicalizeSchema(in)
+	require.NoError(t, err)
+	for i := 0; i < 20; i++ {
+		got, err := canonicalizeSchema(in)
+		require.NoError(t, err)
+		assert.Equalf(t, string(first), string(got), "canonical output must be stable (iteration %d differed)", i)
+	}
+}
+
+func TestCanonicalizeSchema_InvalidJSON(t *testing.T) {
+	_, err := canonicalizeSchema([]byte(`{ not valid json`))
+	assert.Error(t, err)
+}
+
+func TestIsPendingGolden(t *testing.T) {
+	assert.True(t, isPendingGolden([]byte(`{"__pending__": true}`)))
+	assert.False(t, isPendingGolden([]byte(`{"__pending__": false}`)))
+	assert.False(t, isPendingGolden([]byte(`{"collections": []}`)))
+	assert.False(t, isPendingGolden([]byte(`not json at all`)))
+}


### PR DESCRIPTION
## Summary

Adds a **case-level `golden.schema.json`** to the e2e suite: it snapshots the connector's full `GET /schema` output and compares it on every run. This closes a coverage gap — the suite regenerates all DDN metadata from scratch each run and its query goldens are field-addressed, so a change to the generated **NDC schema surface** (e.g. an object-type rename) previously produced **no diff anywhere in version control** and passed silently.

## What it does

- New per-case file `golden.schema.json`, wired into the existing `UPDATE_GOLDEN` regenerate/compare flow and the `{"__pending__": true}` skip sentinel — same conventions as `golden.ddn.json` / `golden.es.json`.
- A `schema-golden` subtest runs right after the connector starts (before the DDN build), so it's captured even if later steps need auth.
- **Determinism:** the connector emits `collections`/`functions`/`procedures` in nondeterministic Go-map order, so the snapshot is canonicalized (those arrays sorted by name; object keys already sorted by the JSON encoder) before writing/comparing. Covered by unit tests that need no Docker.

## How it complements L3

L3 checks *conformance to the live ES mapping* and is **invariant under object-type renames** (it dereferences type refs by field name). This golden is a *snapshot of the generated schema*, so a rename / added / dropped / retyped object now shows up as a reviewable diff and fails the run until deliberately re-approved.

## Test plan

- [x] `go build ./...` and `go build -tags e2e ./...` clean; `go vet -tags e2e` clean; `gofmt` clean
- [x] New unit tests (`schema_golden_test.go`) pass — canonicalization is deterministic/idempotent, pending-sentinel detection
- [x] Full `make -C e2e e2e-update-golden` run green (real ES + connector + DDN + engine): `schema-golden` ✅, L3 ✅, all L4 ✅ for both cases; captured real `golden.schema.json` for `custom_products` and `kibana_sample_logs`; no query goldens changed (confirms determinism)

## Notes

The captured goldens currently pin nested object types under their **bare names** (`manufacturer`, `geo`, …) — this is the pre-fix baseline. A follow-up adds a dedicated collision case; together with #123 (always-FQN) this golden will show the rename as an explicit, gated diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)