### PR TITLE
test(e2e): nested object-type name-collision case (ENT-82) — bug-reproducing

### DIFF
--- a/e2e/cases/nested_collision/case.yaml
+++ b/e2e/cases/nested_collision/case.yaml
@@ -1,0 +1,11 @@
+description: >
+  Nested object-type name collision across two indices (ENT-82 / Zendesk #14975).
+  Both orders_primary and orders_secondary define object fields `subject` and
+  `audit`, but with DIFFERENT shapes. Before the fix, the connector keyed NDC
+  object types by their bare name, so the two `subject` (and two `audit`)
+  definitions collided in a single global map — last-write-wins, nondeterministic
+  Go map order — silently dropping the fields that existed only in the fuller
+  definition (e.g. subject.alternateAccountIdentifier, subject.businessSystemCode,
+  and the audit index:false leaves). The always-fully-qualified fix keeps them
+  distinct (orders_primary.subject vs orders_secondary.subject), so no fields are
+  dropped and the queries below keep returning every selected field.

--- a/e2e/cases/nested_collision/data/orders_primary.ndjson
+++ b/e2e/cases/nested_collision/data/orders_primary.ndjson
@@ -1,0 +1,6 @@
+{"index": {"_index": "orders_primary", "_id": "OP-1"}}
+{"orderId": "OP-1", "amount": 150.0, "subject": {"type": "wire", "alternateAccountIdentifier": "ALT-1", "businessSystemCode": "BSC-1"}, "audit": {"dtLastUpdated": "2024-01-01", "hash": "h1", "mode": "auto"}}
+{"index": {"_index": "orders_primary", "_id": "OP-2"}}
+{"orderId": "OP-2", "amount": 50.0, "subject": {"type": "ach", "alternateAccountIdentifier": "ALT-2", "businessSystemCode": "BSC-2"}, "audit": {"dtLastUpdated": "2024-02-01", "hash": "h2", "mode": "manual"}}
+{"index": {"_index": "orders_primary", "_id": "OP-3"}}
+{"orderId": "OP-3", "amount": 250.0, "subject": {"type": "wire", "alternateAccountIdentifier": "ALT-3", "businessSystemCode": "BSC-3"}, "audit": {"dtLastUpdated": "2024-03-01", "hash": "h3", "mode": "auto"}}

--- a/e2e/cases/nested_collision/data/orders_secondary.ndjson
+++ b/e2e/cases/nested_collision/data/orders_secondary.ndjson
@@ -1,0 +1,4 @@
+{"index": {"_index": "orders_secondary", "_id": "OS-1"}}
+{"orderId": "OS-1", "amount": 75.0, "subject": {"type": "card"}, "audit": {"dtLastUpdated": "2024-01-05"}}
+{"index": {"_index": "orders_secondary", "_id": "OS-2"}}
+{"orderId": "OS-2", "amount": 125.0, "subject": {"type": "cash"}, "audit": {"dtLastUpdated": "2024-02-05"}}

--- a/e2e/cases/nested_collision/golden.schema.json
+++ b/e2e/cases/nested_collision/golden.schema.json
@@ -1,1 +1,886 @@
-{"__pending__": true}
+{
+  "collections": [
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "orders_primary",
+      "type": "orders_primary",
+      "uniqueness_constraints": {}
+    },
+    {
+      "arguments": {
+        "search_after": {
+          "description": "(Optional) The 'search_after' operator in Elasticsearch, used for paginating more than 10,000 results.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "json",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "foreign_keys": {},
+      "name": "orders_secondary",
+      "type": "orders_secondary",
+      "uniqueness_constraints": {}
+    }
+  ],
+  "functions": [],
+  "object_types": {
+    "audit": {
+      "fields": {
+        "dtLastUpdated": {
+          "type": {
+            "name": "date",
+            "type": "named"
+          }
+        },
+        "hash": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "mode": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "date_range_query": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "format": {
+          "description": "(Optional, string) Date format used to convert date values in the query.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "time_zone": {
+          "description": "(Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query to UTC.",
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "orders_primary": {
+      "fields": {
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "amount": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "audit": {
+          "type": {
+            "element_type": {
+              "name": "audit",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "orderId": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "subject": {
+          "type": {
+            "element_type": {
+              "name": "subject",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
+    "orders_secondary": {
+      "fields": {
+        "_id": {
+          "type": {
+            "name": "_id",
+            "type": "named"
+          }
+        },
+        "amount": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "audit": {
+          "type": {
+            "element_type": {
+              "name": "audit",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "orderId": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "subject": {
+          "type": {
+            "element_type": {
+              "name": "subject",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
+    "range": {
+      "fields": {
+        "boost": {
+          "description": "(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.",
+          "type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "gt": {
+          "description": "(Optional) Greater than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "gte": {
+          "description": "(Optional) Greater than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lt": {
+          "description": "(Optional) Less than.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "lte": {
+          "description": "(Optional) Less than or equal.",
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "stats": {
+      "fields": {
+        "avg": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "string_stats": {
+      "fields": {
+        "avg_length": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "count": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "entropy": {
+          "type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "max_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min_length": {
+          "type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "subject": {
+      "fields": {
+        "alternateAccountIdentifier": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "businessSystemCode": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        },
+        "type": {
+          "type": {
+            "name": "keyword",
+            "type": "named"
+          }
+        }
+      }
+    }
+  },
+  "procedures": [],
+  "scalar_types": {
+    "_id": {
+      "aggregate_functions": {},
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "_id",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "_id",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "date": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "date",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "date_range_query",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "date",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "double": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "double",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "double",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "double",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float64"
+      }
+    },
+    "float": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "float",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "float",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "float",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "float32"
+      }
+    },
+    "integer": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "integer",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "integer",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int32"
+      }
+    },
+    "json": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
+      }
+    },
+    "keyword": {
+      "aggregate_functions": {
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "string_stats": {
+          "result_type": {
+            "name": "string_stats",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_bool_prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "prefix": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "regexp": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "keyword",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        },
+        "wildcard": {
+          "argument_type": {
+            "name": "keyword",
+            "type": "named"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "string"
+      }
+    },
+    "long": {
+      "aggregate_functions": {
+        "avg": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "cardinality": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        },
+        "max": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "min": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "stats": {
+          "result_type": {
+            "name": "stats",
+            "type": "named"
+          }
+        },
+        "sum": {
+          "result_type": {
+            "name": "long",
+            "type": "named"
+          }
+        },
+        "value_count": {
+          "result_type": {
+            "name": "integer",
+            "type": "named"
+          }
+        }
+      },
+      "comparison_operators": {
+        "match": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "match_phrase": {
+          "argument_type": {
+            "name": "long",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "range": {
+          "argument_type": {
+            "name": "range",
+            "type": "named"
+          },
+          "type": "custom"
+        },
+        "term": {
+          "type": "equal"
+        },
+        "terms": {
+          "argument_type": {
+            "element_type": {
+              "name": "long",
+              "type": "named"
+            },
+            "type": "array"
+          },
+          "type": "custom"
+        }
+      },
+      "representation": {
+        "type": "int64"
+      }
+    }
+  }
+}

--- a/e2e/cases/nested_collision/golden.schema.json
+++ b/e2e/cases/nested_collision/golden.schema.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/indices/orders_primary.mapping.json
+++ b/e2e/cases/nested_collision/indices/orders_primary.mapping.json
@@ -1,0 +1,22 @@
+{
+  "mappings": {
+    "properties": {
+      "orderId": { "type": "keyword" },
+      "amount": { "type": "double" },
+      "subject": {
+        "properties": {
+          "type": { "type": "keyword" },
+          "alternateAccountIdentifier": { "type": "keyword" },
+          "businessSystemCode": { "type": "keyword" }
+        }
+      },
+      "audit": {
+        "properties": {
+          "dtLastUpdated": { "type": "date" },
+          "hash": { "type": "keyword", "index": false },
+          "mode": { "type": "keyword", "index": false }
+        }
+      }
+    }
+  }
+}

--- a/e2e/cases/nested_collision/indices/orders_secondary.mapping.json
+++ b/e2e/cases/nested_collision/indices/orders_secondary.mapping.json
@@ -1,0 +1,18 @@
+{
+  "mappings": {
+    "properties": {
+      "orderId": { "type": "keyword" },
+      "amount": { "type": "double" },
+      "subject": {
+        "properties": {
+          "type": { "type": "keyword" }
+        }
+      },
+      "audit": {
+        "properties": {
+          "dtLastUpdated": { "type": "date" }
+        }
+      }
+    }
+  }
+}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/es_search.json
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/es_search.json
@@ -1,0 +1,21 @@
+{
+  "size": 50,
+  "_source": [
+    "orderId",
+    "amount",
+    "subject.type",
+    "subject.businessSystemCode"
+  ],
+  "query": {
+    "range": {
+      "amount": {
+        "gt": 100
+      }
+    }
+  },
+  "sort": [
+    {
+      "orderId": "asc"
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.ddn.json
@@ -1,1 +1,24 @@
-{"__pending__": true}
+{
+  "ordersPrimary": [
+    {
+      "amount": 150,
+      "orderId": "OP-1",
+      "subject": [
+        {
+          "businessSystemCode": "BSC-1",
+          "type": "wire"
+        }
+      ]
+    },
+    {
+      "amount": 250,
+      "orderId": "OP-3",
+      "subject": [
+        {
+          "businessSystemCode": "BSC-3",
+          "type": "wire"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.ddn.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.es.json
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.es.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.es.json
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/golden.es.json
@@ -1,1 +1,40 @@
-{"__pending__": true}
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "amount": 150,
+          "orderId": "OP-1",
+          "subject": {
+            "businessSystemCode": "BSC-1",
+            "type": "wire"
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "amount": 250,
+          "orderId": "OP-3",
+          "subject": {
+            "businessSystemCode": "BSC-3",
+            "type": "wire"
+          }
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 2
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/query.graphql
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/query.graphql
@@ -1,0 +1,10 @@
+query FilterPrimaryByAmount {
+  ordersPrimary(where: { amount: { range: { gt: 100 } } }, order_by: { orderId: Asc }) {
+    orderId
+    amount
+    subject {
+      type
+      businessSystemCode
+    }
+  }
+}

--- a/e2e/cases/nested_collision/queries/filter_primary_by_amount/target.yaml
+++ b/e2e/cases/nested_collision/queries/filter_primary_by_amount/target.yaml
@@ -1,0 +1,2 @@
+index: "orders_primary"
+description: "FILTER orders_primary by amount > 100, still selecting collision-affected nested subject fields."

--- a/e2e/cases/nested_collision/queries/select_primary_nested/es_search.json
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/es_search.json
@@ -1,0 +1,17 @@
+{
+  "size": 50,
+  "_source": [
+    "orderId",
+    "subject.type",
+    "subject.alternateAccountIdentifier",
+    "subject.businessSystemCode",
+    "audit.dtLastUpdated",
+    "audit.hash",
+    "audit.mode"
+  ],
+  "sort": [
+    {
+      "orderId": "asc"
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/golden.ddn.json
@@ -1,1 +1,55 @@
-{"__pending__": true}
+{
+  "ordersPrimary": [
+    {
+      "audit": [
+        {
+          "dtLastUpdated": "2024-01-01",
+          "hash": "h1",
+          "mode": "auto"
+        }
+      ],
+      "orderId": "OP-1",
+      "subject": [
+        {
+          "alternateAccountIdentifier": "ALT-1",
+          "businessSystemCode": "BSC-1",
+          "type": "wire"
+        }
+      ]
+    },
+    {
+      "audit": [
+        {
+          "dtLastUpdated": "2024-02-01",
+          "hash": "h2",
+          "mode": "manual"
+        }
+      ],
+      "orderId": "OP-2",
+      "subject": [
+        {
+          "alternateAccountIdentifier": "ALT-2",
+          "businessSystemCode": "BSC-2",
+          "type": "ach"
+        }
+      ]
+    },
+    {
+      "audit": [
+        {
+          "dtLastUpdated": "2024-03-01",
+          "hash": "h3",
+          "mode": "auto"
+        }
+      ],
+      "orderId": "OP-3",
+      "subject": [
+        {
+          "alternateAccountIdentifier": "ALT-3",
+          "businessSystemCode": "BSC-3",
+          "type": "wire"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/golden.ddn.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/golden.es.json
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/golden.es.json
@@ -1,1 +1,66 @@
-{"__pending__": true}
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "audit": {
+            "dtLastUpdated": "2024-01-01",
+            "hash": "h1",
+            "mode": "auto"
+          },
+          "orderId": "OP-1",
+          "subject": {
+            "alternateAccountIdentifier": "ALT-1",
+            "businessSystemCode": "BSC-1",
+            "type": "wire"
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "audit": {
+            "dtLastUpdated": "2024-02-01",
+            "hash": "h2",
+            "mode": "manual"
+          },
+          "orderId": "OP-2",
+          "subject": {
+            "alternateAccountIdentifier": "ALT-2",
+            "businessSystemCode": "BSC-2",
+            "type": "ach"
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "audit": {
+            "dtLastUpdated": "2024-03-01",
+            "hash": "h3",
+            "mode": "auto"
+          },
+          "orderId": "OP-3",
+          "subject": {
+            "alternateAccountIdentifier": "ALT-3",
+            "businessSystemCode": "BSC-3",
+            "type": "wire"
+          }
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 3
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/golden.es.json
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/golden.es.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/query.graphql
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/query.graphql
@@ -1,0 +1,15 @@
+query SelectPrimaryNested {
+  ordersPrimary(order_by: { orderId: Asc }) {
+    orderId
+    subject {
+      type
+      alternateAccountIdentifier
+      businessSystemCode
+    }
+    audit {
+      dtLastUpdated
+      hash
+      mode
+    }
+  }
+}

--- a/e2e/cases/nested_collision/queries/select_primary_nested/target.yaml
+++ b/e2e/cases/nested_collision/queries/select_primary_nested/target.yaml
@@ -1,0 +1,2 @@
+index: "orders_primary"
+description: "SELECT orders_primary with the full subject + audit nested objects (the fields that collide-drop on main)."

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/es_search.json
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/es_search.json
@@ -1,0 +1,13 @@
+{
+  "size": 50,
+  "_source": [
+    "orderId",
+    "subject.type",
+    "audit.dtLastUpdated"
+  ],
+  "sort": [
+    {
+      "orderId": "asc"
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/golden.ddn.json
@@ -1,1 +1,30 @@
-{"__pending__": true}
+{
+  "ordersSecondary": [
+    {
+      "audit": [
+        {
+          "dtLastUpdated": "2024-01-05"
+        }
+      ],
+      "orderId": "OS-1",
+      "subject": [
+        {
+          "type": "card"
+        }
+      ]
+    },
+    {
+      "audit": [
+        {
+          "dtLastUpdated": "2024-02-05"
+        }
+      ],
+      "orderId": "OS-2",
+      "subject": [
+        {
+          "type": "cash"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/golden.ddn.json
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/golden.ddn.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/golden.es.json
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/golden.es.json
@@ -1,0 +1,1 @@
+{"__pending__": true}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/golden.es.json
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/golden.es.json
@@ -1,1 +1,42 @@
-{"__pending__": true}
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "audit": {
+            "dtLastUpdated": "2024-01-05"
+          },
+          "orderId": "OS-1",
+          "subject": {
+            "type": "card"
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "audit": {
+            "dtLastUpdated": "2024-02-05"
+          },
+          "orderId": "OS-2",
+          "subject": {
+            "type": "cash"
+          }
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 2
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/query.graphql
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/query.graphql
@@ -1,0 +1,11 @@
+query SelectSecondaryNested {
+  ordersSecondary(order_by: { orderId: Asc }) {
+    orderId
+    subject {
+      type
+    }
+    audit {
+      dtLastUpdated
+    }
+  }
+}

--- a/e2e/cases/nested_collision/queries/select_secondary_nested/target.yaml
+++ b/e2e/cases/nested_collision/queries/select_secondary_nested/target.yaml
@@ -1,0 +1,2 @@
+index: "orders_secondary"
+description: "SELECT orders_secondary — the minimal-shape twin whose subject/audit share a name with orders_primary."


### PR DESCRIPTION
## Summary

Adds an e2e case, `nested_collision`, that reproduces the nested object-type name-collision bug (Linear ENT-82 / Zendesk #14975) **end-to-end through the real ES → connector → DDN → GraphQL stack**. It lands in `main` **before** the fix (#123) so #123 can be validated against it: the fix should turn this case from flaky/red to deterministically green.

## ⚠️ Intentionally FLAKY/RED on `main`

The case **encodes the bug**, so it does not reliably pass on the current (unfixed) connector — by design. Two indices define object fields `subject` and `audit` with different shapes:

- `orders_primary`: `subject { type, alternateAccountIdentifier, businessSystemCode }`, `audit { dtLastUpdated, hash (index:false), mode (index:false) }`
- `orders_secondary`: `subject { type }`, `audit { dtLastUpdated }`

The bare-name NDC object types collide in one global map (last-writer-wins, nondeterministic Go map order), so each run is a coin-flip:

- **Fuller shape wins** → matches the committed baseline goldens → green.
- **Minimal shape wins** → `orders_primary`'s extra fields vanish → `golden.schema.json` mismatches, L3 fails, and the `orders_primary` query goldens are unreachable (GraphQL `no such field on type Subject`) → red.

So expect **~50/50 flaky** CI here. That flakiness *is* the bug's signature.

## Goldens (filled — pre-fix baseline)

All goldens are committed with the **current pre-fix output**, captured via `UPDATE_GOLDEN=1` (no longer `__pending__` sentinels):

- `golden.schema.json` — bare `subject`/`audit`, reflecting whichever shape won the collision when captured (the fuller shape this time).
- each query's `golden.ddn.json` / `golden.es.json`.

The schema-golden harness (#131) and the source-rebuild fix (#133) are already on `main`, so the `golden.schema.json` guard is **active** on this branch (compared, not skipped) and the connector is always rebuilt from source. When #123 lands, the schema becomes fully-qualified and deterministic, these baseline goldens fail, and you regenerate with `UPDATE_GOLDEN=1` — that diff (bare → fully-qualified, dropped fields recovered) is the reviewable proof of the fix.

## What #123 does to it (verified locally)

Built a connector from #123 and ran this case:

- object types split into distinct `orders_primary.subject` / `orders_secondary.subject` (+ audit), **all fields retained**;
- schema is deterministic; L3 + all three L4 queries pass;
- the DDN CLI keeps the two fully-qualified types **distinct** (does not collapse them to one `Subject`), so `orders_primary` returns `subject: [{type, alternateAccountIdentifier, businessSystemCode}]` and `audit: [{dtLastUpdated, hash, mode}]` — every field, including the `index:false` leaves.

## Note

If the `E2E` workflow is a required merge check, merging this before #123 needs an override, since the case is flaky/red on `main` until #123 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
