### PR TITLE
fix(e2e): rebuild connector image from source each run (--build)

### DIFF
--- a/e2e/harness/stack.go
+++ b/e2e/harness/stack.go
@@ -158,8 +158,10 @@ func (s *Stack) KibanaBaseURL() string {
 func (s *Stack) Introspect(ctx context.Context) error {
 	t := s.startTimer("stack:introspect")
 	defer t.done()
+	// --build so we never run a stale cached image. Introspect uses the same
+	// image the connector serves from, so it must rebuild too.
 	_, err := mustRun(ctx, s.env.E2EDir, s.composeEnv(), "docker",
-		s.compose("--profile", "tools", "run", "--rm", "introspect")...)
+		s.compose("--profile", "tools", "run", "--rm", "--build", "introspect")...)
 	if err != nil {
 		return fmt.Errorf("connector introspection (update) failed: %w", err)
 	}
@@ -230,8 +232,9 @@ func filterKibanaConfig(cfgPath, kibanaSampleKind string) error {
 func (s *Stack) StartConnector(ctx context.Context) error {
 	t := s.startTimer("stack:connector-up")
 	defer t.done()
+	// --build to match Introspect; near no-op via layer cache if source unchanged.
 	if _, err := mustRun(ctx, s.env.E2EDir, s.composeEnv(), "docker",
-		s.compose("up", "-d", "--wait", "ndc-elasticsearch")...); err != nil {
+		s.compose("up", "-d", "--wait", "--build", "ndc-elasticsearch")...); err != nil {
 		return fmt.Errorf("bringing up connector: %w", err)
 	}
 	return waitHTTP(ctx, fmt.Sprintf("http://localhost:%d/health", s.Ports["connector"]), 90*time.Second)


### PR DESCRIPTION
## Problem

The e2e harness builds the connector image from local source (repo-root `Dockerfile`, `COPY . . && go build`) and tags it `ndc-elasticsearch-e2e:<STACK_VERSION>`. But it invoked `docker compose up`/`run` **without `--build`**, so Compose reused a previously-built image whenever the tag already existed. A code change or branch switch would then be **silently tested against a stale connector binary**.

This is masked on CI (ephemeral runners have no cached image, so every run builds fresh) but bites local validation — e.g. switching to a fix branch and re-running silently ran the old binary until the image was manually removed.

## Fix

Add `--build` to both connector-image invocations in `stack.go`:
- `Introspect` — `compose run --rm --build introspect`
- `StartConnector` — `compose up -d --wait --build ndc-elasticsearch`

The **introspect** step is the important one: it runs the *same* image first (as `update`), so if only serve rebuilt, `configuration.json` would still be produced by stale code. With `--build` on introspect, the image is rebuilt from current source before anything uses it; the `up --build` is belt-and-suspenders and is a near no-op via Docker layer caching when the source is unchanged.

Only the two built-from-source services get `--build`; ES/Kibana/engine are pulled images and are untouched.

## Verification

- `go build -tags e2e` / `go vet -tags e2e` / `gofmt` clean.
- Confirmed `--build` is a valid flag for both `up` and `run` on Compose v2.31.
- Independently corroborated earlier: removing the cached tag and re-running produced the fix's fully-qualified output, proving the build tracks working-tree source — this change makes that automatic.

Independent of the schema-golden (#131) and collision-case (#132) PRs; can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)