### PR TITLE
test(e2e): query coverage for nested objects renamed by the object-type fix

### DIFF
--- a/e2e/cases/custom_products/queries/select_manufacturer/es_search.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer/es_search.json
@@ -1,0 +1,13 @@
+{
+  "size": 3,
+  "_source": [
+    "sku",
+    "manufacturer.name",
+    "manufacturer.country"
+  ],
+  "sort": [
+    {
+      "sku": "asc"
+    }
+  ]
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer/golden.ddn.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer/golden.ddn.json
@@ -1,0 +1,31 @@
+{
+  "products": [
+    {
+      "manufacturer": [
+        {
+          "country": "US",
+          "name": "Acme"
+        }
+      ],
+      "sku": "PRD-001"
+    },
+    {
+      "manufacturer": [
+        {
+          "country": "US",
+          "name": "Acme"
+        }
+      ],
+      "sku": "PRD-002"
+    },
+    {
+      "manufacturer": [
+        {
+          "country": "DE",
+          "name": "Globex"
+        }
+      ],
+      "sku": "PRD-003"
+    }
+  ]
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer/golden.es.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer/golden.es.json
@@ -1,0 +1,48 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "US",
+            "name": "Acme"
+          },
+          "sku": "PRD-001"
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "US",
+            "name": "Acme"
+          },
+          "sku": "PRD-002"
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "DE",
+            "name": "Globex"
+          },
+          "sku": "PRD-003"
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 6
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer/query.graphql
+++ b/e2e/cases/custom_products/queries/select_manufacturer/query.graphql
@@ -1,0 +1,9 @@
+query SelectManufacturer {
+  products(order_by: { sku: Asc }, limit: 3) {
+    sku
+    manufacturer {
+      name
+      country
+    }
+  }
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer/target.yaml
+++ b/e2e/cases/custom_products/queries/select_manufacturer/target.yaml
@@ -1,0 +1,2 @@
+index: "products"
+description: "SELECT the nested manufacturer object (type renamed to products.manufacturer under the fix)."

--- a/e2e/cases/custom_products/queries/select_manufacturer_alias/es_search.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer_alias/es_search.json
@@ -1,0 +1,13 @@
+{
+  "size": 3,
+  "_source": [
+    "sku",
+    "manufacturer.name",
+    "manufacturer.country"
+  ],
+  "sort": [
+    {
+      "sku": "asc"
+    }
+  ]
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer_alias/golden.ddn.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer_alias/golden.ddn.json
@@ -1,0 +1,31 @@
+{
+  "productsAlias": [
+    {
+      "manufacturer": [
+        {
+          "country": "US",
+          "name": "Acme"
+        }
+      ],
+      "sku": "PRD-001"
+    },
+    {
+      "manufacturer": [
+        {
+          "country": "US",
+          "name": "Acme"
+        }
+      ],
+      "sku": "PRD-002"
+    },
+    {
+      "manufacturer": [
+        {
+          "country": "DE",
+          "name": "Globex"
+        }
+      ],
+      "sku": "PRD-003"
+    }
+  ]
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer_alias/golden.es.json
+++ b/e2e/cases/custom_products/queries/select_manufacturer_alias/golden.es.json
@@ -1,0 +1,48 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "US",
+            "name": "Acme"
+          },
+          "sku": "PRD-001"
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "US",
+            "name": "Acme"
+          },
+          "sku": "PRD-002"
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "manufacturer": {
+            "country": "DE",
+            "name": "Globex"
+          },
+          "sku": "PRD-003"
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 6
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer_alias/query.graphql
+++ b/e2e/cases/custom_products/queries/select_manufacturer_alias/query.graphql
@@ -1,0 +1,9 @@
+query SelectManufacturerAlias {
+  productsAlias(order_by: { sku: Asc }, limit: 3) {
+    sku
+    manufacturer {
+      name
+      country
+    }
+  }
+}

--- a/e2e/cases/custom_products/queries/select_manufacturer_alias/target.yaml
+++ b/e2e/cases/custom_products/queries/select_manufacturer_alias/target.yaml
@@ -1,0 +1,2 @@
+index: "products_alias"
+description: "SELECT manufacturer via the products_alias collection (a separate products_alias.manufacturer type under the fix)."

--- a/e2e/cases/kibana_sample_logs/queries/select_event_machine/es_search.json
+++ b/e2e/cases/kibana_sample_logs/queries/select_event_machine/es_search.json
@@ -1,0 +1,14 @@
+{
+  "size": 5,
+  "_source": [
+    "bytes",
+    "event.dataset",
+    "machine.os",
+    "machine.ram"
+  ],
+  "sort": [
+    {
+      "bytes": "desc"
+    }
+  ]
+}

--- a/e2e/cases/kibana_sample_logs/queries/select_event_machine/golden.ddn.json
+++ b/e2e/cases/kibana_sample_logs/queries/select_event_machine/golden.ddn.json
@@ -1,0 +1,74 @@
+{
+  "kibanaSampleDataLogs": [
+    {
+      "bytes": 19986,
+      "event": [
+        {
+          "dataset": "sample_web_logs"
+        }
+      ],
+      "machine": [
+        {
+          "os": "osx",
+          "ram": 6442450944
+        }
+      ]
+    },
+    {
+      "bytes": 19956,
+      "event": [
+        {
+          "dataset": "sample_web_logs"
+        }
+      ],
+      "machine": [
+        {
+          "os": "ios",
+          "ram": 19327352832
+        }
+      ]
+    },
+    {
+      "bytes": 19929,
+      "event": [
+        {
+          "dataset": "sample_web_logs"
+        }
+      ],
+      "machine": [
+        {
+          "os": "osx",
+          "ram": 20401094656
+        }
+      ]
+    },
+    {
+      "bytes": 19919,
+      "event": [
+        {
+          "dataset": "sample_web_logs"
+        }
+      ],
+      "machine": [
+        {
+          "os": "ios",
+          "ram": 12884901888
+        }
+      ]
+    },
+    {
+      "bytes": 19904,
+      "event": [
+        {
+          "dataset": "sample_web_logs"
+        }
+      ],
+      "machine": [
+        {
+          "os": "win 7",
+          "ram": 3221225472
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/cases/kibana_sample_logs/queries/select_event_machine/golden.es.json
+++ b/e2e/cases/kibana_sample_logs/queries/select_event_machine/golden.es.json
@@ -1,0 +1,83 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "hits": {
+    "hits": [
+      {
+        "_score": null,
+        "_source": {
+          "bytes": 19986,
+          "event": {
+            "dataset": "sample_web_logs"
+          },
+          "machine": {
+            "os": "osx",
+            "ram": 6442450944
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "bytes": 19956,
+          "event": {
+            "dataset": "sample_web_logs"
+          },
+          "machine": {
+            "os": "ios",
+            "ram": 19327352832
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "bytes": 19929,
+          "event": {
+            "dataset": "sample_web_logs"
+          },
+          "machine": {
+            "os": "osx",
+            "ram": 20401094656
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "bytes": 19919,
+          "event": {
+            "dataset": "sample_web_logs"
+          },
+          "machine": {
+            "os": "ios",
+            "ram": 12884901888
+          }
+        }
+      },
+      {
+        "_score": null,
+        "_source": {
+          "bytes": 19904,
+          "event": {
+            "dataset": "sample_web_logs"
+          },
+          "machine": {
+            "os": "win 7",
+            "ram": 3221225472
+          }
+        }
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "gte",
+      "value": 10000
+    }
+  },
+  "timed_out": false
+}

--- a/e2e/cases/kibana_sample_logs/queries/select_event_machine/query.graphql
+++ b/e2e/cases/kibana_sample_logs/queries/select_event_machine/query.graphql
@@ -1,0 +1,12 @@
+query SelectEventMachine {
+  kibanaSampleDataLogs(order_by: { bytes: Desc }, limit: 5) {
+    bytes
+    event {
+      dataset
+    }
+    machine {
+      os
+      ram
+    }
+  }
+}

--- a/e2e/cases/kibana_sample_logs/queries/select_event_machine/target.yaml
+++ b/e2e/cases/kibana_sample_logs/queries/select_event_machine/target.yaml
@@ -1,0 +1,2 @@
+index: "kibana_sample_data_logs"
+description: "SELECT the nested event + machine objects (types renamed to kibana_sample_data_logs.event / .machine under the fix)."


### PR DESCRIPTION
## Summary

Adds e2e **query** coverage for the nested object types that #123 renames but that no existing query exercised. Today the schema-golden snapshot captures the rename, but only some renamed types were actually selected by a query — this fills the gaps so the fix is validated at the **query layer**, not just the schema snapshot.

Coverage before this PR (renamed type → had a query?):

| Case | nested object | before | this PR |
|---|---|---|---|
| `nested_collision` | `subject` / `audit` | ✅ | — |
| `kibana_sample_logs` | `geo` | ✅ | — |
| `custom_products` | `manufacturer` | ❌ | ✅ `select_manufacturer` (+ `_alias`) |
| `kibana_sample_logs` | `event` | ❌ | ✅ `select_event_machine` |
| `kibana_sample_logs` | `machine` | ❌ | ✅ `select_event_machine` |

## New queries

- `custom_products/select_manufacturer` — `manufacturer { name country }` on `products`.
- `custom_products/select_manufacturer_alias` — same on the `products_alias` collection. The fix splits the shared bare `manufacturer` into distinct `products.manufacturer` / `products_alias.manufacturer`, so both are now queried.
- `kibana_sample_logs/select_event_machine` — `event { dataset }` + `machine { os ram }`.

## Why on a fix-free branch (TDD pattern, like #132)

Goldens are captured on `main` (pre-fix). These fields don't collide, so the queries are **deterministic and green here**. When #123 is run/rebased against this branch:

- **query goldens should stay byte-identical** — the fix renames *types*, not field names or values, so `products { manufacturer { name country } }` etc. return exactly the same data. That's the proof queries keep working across the rename.
- **schema goldens change** (bare → fully-qualified) — expected, and already handled in #123.

## Verified locally

Ran `UPDATE_GOLDEN=1` for both cases on this branch (fix-free, `--build`): all queries pass, and the captured DDN goldens return the nested objects (`manufacturer: [{name, country}]`, `event: [{dataset}]`, `machine: [{os, ram}]`). Only the three new query dirs are added — no existing goldens or schema goldens changed.

Note: `nested_collision` (already in `main`) remains flaky pre-fix by design; any CI flake here from that case is inherited from `main`, not introduced by these additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)