### PR TITLE
docs(changelog): add v2.0.0 (breaking — fully-qualified object-type names)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
+- **BREAKING:** Fix NDC object-type name collisions that silently dropped nested fields; nested object types are now fully-qualified (e.g. `products.manufacturer`) instead of bare names. Re-introspect and re-track after upgrading. ([#123](https://github.com/hasura/ndc-elasticsearch/pull/123))
+
 ## [1.10.4]
 
 - Fix concurrent-reauth data race on `e.client`. ([#124](https://github.com/hasura/ndc-elasticsearch/pull/124))


### PR DESCRIPTION
## Summary

Adds the `## [2.0.0]` CHANGELOG section for the release. **This must merge to `main` before the `v2.0.0` tag is pushed** — the `deploy-stage.yaml` release job reads the matching CHANGELOG section (`changelog-reader-action`) for the release body, and fails if it's absent.

## Why v2.0.0 (major)

#123 renames every nested object type from its bare field name to a fully-qualified `index.path.to.field` name (e.g. `manufacturer` → `products.manufacturer`). That's a **breaking change to the generated GraphQL type surface**:
- Query behavior is unchanged (fields are selected by name) — verified end-to-end by the e2e query goldens matching across the fix.
- But existing DDN projects must **re-introspect + re-track** the affected models/types, and consumers pinned to the old type names (fragments, generated SDKs) must update.

## Release steps (after this merges)

1. Merge this PR to `main`.
2. Tag `v2.0.0` on that commit and push → `deploy-stage.yaml` builds/pushes the `ghcr.io/hasura/ndc-elasticsearch:v2.0.0` image, builds the CLI binaries + connector-definition, and creates a **draft** GitHub release from this CHANGELOG section.
3. Review and publish the draft release.

No template edits needed — `connector-metadata.yaml` / `manifest.yaml` are `envsubst`'d with the tag version at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)